### PR TITLE
Lazy dep on Muon.jl for loading h5ad files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3] - 2024-11-06
+
+### Added
+
+* Package extension for `Muon.jl` that allows loading data from .h5ad files using the functions `create_datamatrix`, `create_var` and `create_obs`.
+
+### Fixed
+
+* Deprecated old `loadh5ad` function that only supported some versions of the .h5ad format.
+
 ## [0.4.2] - 2024-09-27
 
 ### Fixed

--- a/Project.toml
+++ b/Project.toml
@@ -23,13 +23,15 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 ThreadedSparseArrays = "59d54670-b8ac-4d81-ab7a-bb56233e17ab"
 
 [weakdeps]
-Requires = "ae029012-a4dd-5104-9daa-d747884805df"
+Muon = "446846d7-b4ce-489d-bf74-72da18fe3629"
 PrincipalMomentAnalysis = "6a3ba550-3b7f-11e9-2734-d9178ad1e8db"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 TSne = "24678dba-d5e9-5843-a4c6-250288b04835"
 UMAP = "c4f8c510-2410-5be4-91d7-4fbaeb39457e"
 
 [extensions]
+SingleCellProjectionsMuonExt = "Muon"
 SingleCellProjectionsPrincipalMomentAnalysisExt = "PrincipalMomentAnalysis"
 SingleCellProjectionsStableRNGsExt = "StableRNGs"
 SingleCellProjectionsTSneExt = "TSne"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SingleCellProjections"
 uuid = "03d38035-ed2f-4a36-82eb-797f1727ab2e"
 authors = ["Rasmus Henningsson <rasmus.henningsson@med.lu.se>"]
-version = "0.4.2"
+version = "0.4.3"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/ext/SingleCellProjectionsMuonExt.jl
+++ b/ext/SingleCellProjectionsMuonExt.jl
@@ -75,6 +75,8 @@ kwargs:
 * add_var: Add `var` from the AnnData object to the returned `DataMatrix` (when applicable).
 * add_obs: Add `obs` from the AnnData object to the returned `DataMatrix` (when applicable).
 
+!!! note
+	The interface for loading from .h5ad files is still considered experimental and might change in a non-breaking release.
 
 # Examples
 

--- a/ext/SingleCellProjectionsMuonExt.jl
+++ b/ext/SingleCellProjectionsMuonExt.jl
@@ -125,7 +125,7 @@ DataMatrix (123 variables and 456 observations)
 ```julia
 julia> create_datamatrix(a.obsm, "UMAP")
 DataMatrix (2 variables and 456 observations)
-  SparseMatrixCSC{Float64, Int32}
+  Matrix{Float64}
   Variables: id
   Observations: cell_id
 ```

--- a/ext/SingleCellProjectionsMuonExt.jl
+++ b/ext/SingleCellProjectionsMuonExt.jl
@@ -1,0 +1,86 @@
+module SingleCellProjectionsMuonExt
+
+using SingleCellProjections
+using DataFrames
+
+if isdefined(Base, :get_extension)
+	using Muon: AnnData, AlignedMapping
+else
+	using ..Muon: AnnData, AlignedMapping
+end
+
+
+function aligned_mapping_type(am::AlignedMapping)
+	ref = am.ref
+	am === ref.layers && return :layers
+	am === ref.obsm && return :obsm
+	am === ref.obsp && return :obsp
+	am === ref.varm && return :varm
+	am === ref.varp && return :varp
+	throw(ArgumentError("Unknown AlignedMapping"))
+end
+
+
+function get_var(a::AnnData; add_var)
+	id = collect(a.var_names)
+	if add_var
+		var = a.var
+		var = insertcols(var, 1, :id=>id; makeunique=true)
+		return var
+	else
+		return DataFrame(; id)
+	end
+end
+function get_obs(a::AnnData; add_obs)
+	cell_id = collect(a.obs_names)
+	if add_obs
+		obs = a.obs
+		obs = insertcols(obs, 1, :cell_id=>cell_id; makeunique=true)
+		return obs
+	else
+		return DataFrame(; cell_id)
+	end
+end
+
+
+
+function SingleCellProjections.create_datamatrix(a::AnnData; add_var=false, add_obs=false)
+	X = a.X'
+	var = get_var(a; add_var)
+	obs = get_obs(a; add_obs)
+	DataMatrix(X, var, obs)
+end
+
+
+function SingleCellProjections.create_datamatrix(am::AlignedMapping, name; add_var=false, add_obs=false)
+	a = am.ref
+	am_type = aligned_mapping_type(am)
+
+	X = am[name]
+	if am_type in (:layers, :obsm, :obsp)
+	end
+
+	if am_type == :layers
+		X = X'
+		var = get_var(a; add_var)
+		obs = get_obs(a; add_obs)
+	elseif am_type == :obsm
+		X = X'
+		var = string.("Dim", 1:size(X,1))
+		obs = get_obs(a; add_obs)
+	elseif am_type == :obsp
+		X = X'
+		var = obs = get_obs(a; add_obs)
+	elseif am_type == :varm
+		dim1 = get_var(a; add_var)
+		dim2 = string.("Dim", 1:size(X,2))
+	elseif am_type == :varp
+		var = obs = get_var(a; add_var)
+	end
+
+	DataMatrix(X, var, obs)
+end
+
+
+
+end

--- a/ext/SingleCellProjectionsMuonExt.jl
+++ b/ext/SingleCellProjectionsMuonExt.jl
@@ -74,14 +74,14 @@ function SingleCellProjections.create_datamatrix(::Type{T}, am::AlignedMapping, 
 		obs = get_obs(a; add_obs)
 	elseif am_type == :obsm
 		X = X'
-		var = string.("Dim", 1:size(X,1))
+		var = DataFrame(; id=string.("Dim", 1:size(X,1)))
 		obs = get_obs(a; add_obs)
 	elseif am_type == :obsp
 		X = X'
 		var = obs = get_obs(a; add_obs)
 	elseif am_type == :varm
 		dim1 = get_var(a; add_var)
-		dim2 = string.("Dim", 1:size(X,2))
+		dim2 = DataFrame(; id=string.("Dim", 1:size(X,2)))
 	elseif am_type == :varp
 		var = obs = get_var(a; add_var)
 	end

--- a/ext/SingleCellProjectionsMuonExt.jl
+++ b/ext/SingleCellProjectionsMuonExt.jl
@@ -25,6 +25,9 @@ end
 
 Create a `DataFrame` where the first column contains `var` IDs and the remaining columns contain the `var` annotations from the `AnnData` object.
 
+!!! note
+	The interface for loading data from .h5ad files is still considered experimental and might change in a non-breaking release.
+
 See also: [`create_datamatrix`](@ref), [`create_obs`](@ref)
 """
 SingleCellProjections.create_var(a::AnnData) =
@@ -34,6 +37,9 @@ SingleCellProjections.create_var(a::AnnData) =
 	create_obs(a::AnnData)
 
 Create a `DataFrame` where the first column contains `obs` IDs and the remaining columns contain the `obs` annotations from the `AnnData` object.
+
+!!! note
+	The interface for loading data from .h5ad files is still considered experimental and might change in a non-breaking release.
 
 See also: [`create_datamatrix`](@ref), [`create_var`](@ref)
 """
@@ -76,7 +82,7 @@ kwargs:
 * add_obs: Add `obs` from the AnnData object to the returned `DataMatrix` (when applicable).
 
 !!! note
-	The interface for loading from .h5ad files is still considered experimental and might change in a non-breaking release.
+	The interface for loading data from .h5ad files is still considered experimental and might change in a non-breaking release.
 
 # Examples
 

--- a/src/SingleCellProjections.jl
+++ b/src/SingleCellProjections.jl
@@ -59,7 +59,9 @@ export
 	mannwhitney!,
 	mannwhitney,
 	mannwhitney_table,
-	create_datamatrix
+	create_datamatrix,
+	create_var,
+	create_obs
 
 using LinearAlgebra
 import LinearAlgebra: svd

--- a/src/SingleCellProjections.jl
+++ b/src/SingleCellProjections.jl
@@ -58,7 +58,8 @@ export
 	ttest_table,
 	mannwhitney!,
 	mannwhitney,
-	mannwhitney_table
+	mannwhitney_table,
+	create_datamatrix
 
 using LinearAlgebra
 import LinearAlgebra: svd

--- a/src/SingleCellProjections.jl
+++ b/src/SingleCellProjections.jl
@@ -140,6 +140,7 @@ include("precompile.jl")
 		@require TSne="24678dba-d5e9-5843-a4c6-250288b04835" include("../ext/SingleCellProjectionsTSneExt.jl")
 		@require PrincipalMomentAnalysis="6a3ba550-3b7f-11e9-2734-d9178ad1e8db" include("../ext/SingleCellProjectionsPrincipalMomentAnalysisExt.jl")
 		@require StableRNGs="860ef19b-820b-49d6-a774-d7a799459cd3" include("../ext/SingleCellProjectionsStableRNGsExt.jl")
+		@require Muon="446846d7-b4ce-489d-bf74-72da18fe3629" include("../ext/SingleCellProjectionsMuonExt.jl")
 	end
 end
 

--- a/src/datamatrix.jl
+++ b/src/datamatrix.jl
@@ -44,7 +44,7 @@ struct DataMatrix{T,Tv,To}
 		end
 
 		validateunique_var(var, 1; report=duplicate_var)
-		validateunique_var(obs, 1; report=duplicate_obs)
+		validateunique_obs(obs, 1; report=duplicate_obs)
 		new{T,Tv,To}(matrix, var, obs, models)
 	end
 end

--- a/src/h5ad.jl
+++ b/src/h5ad.jl
@@ -57,8 +57,13 @@ end
 	loadh5ad(filename; var_id_column=:id, obs_id_column=:id)
 
 Experimental loading of .h5ad files.
+
+!!! note
+	This function is deprecated. Load `Muon.jl` and see help for `create_datamatrix`.
 """
 function loadh5ad(filename; obs_id_column=:id, var_id_col=:id)
+	@warn "loadh5ad is deprecated, please load Muon.jl and see help for `create_datamatrix`." maxlog=1
+
 	h5open(filename) do h5
 		@assert read(attributes(h5), "encoding-type") == "anndata"
 

--- a/src/h5ad.jl
+++ b/src/h5ad.jl
@@ -1,4 +1,6 @@
 function create_datamatrix end
+function create_var end
+function create_obs end
 
 
 _readh5ad_dataframe_string_array(g) = read(g)

--- a/src/h5ad.jl
+++ b/src/h5ad.jl
@@ -1,3 +1,4 @@
+function create_datamatrix end
 
 
 _readh5ad_dataframe_string_array(g) = read(g)


### PR DESCRIPTION
Adds `create_datamatrix(a::AnnData, ...)` which can be used to load `h5ad` files via `a = readh5ad(path)` from `Muon`.

Implemented using package extensions to avoid adding `Muon` as a dependency.