### PR TITLE
Mtx loading

### DIFF
--- a/ext/CSVExt.jl
+++ b/ext/CSVExt.jl
@@ -2,7 +2,8 @@ module CSVExt
 
 using ReproducibleJobs
 using ReproducibleJobs: create_job, cached, Preprocess, Preprocessing
-using SingleCellProjections
+import SingleCellProjections as SCP
+# using SingleCellProjections
 using SingleCellProjections.Impl: table_to_compound_result, table_from_compound_result
 
 using DataFrames
@@ -27,7 +28,7 @@ parse_csv_job(filepath; kwargs...) =
 
 load_csv(::Preprocessing, filepath; kwargs...) =
 	table_from_compound_result(parse_csv_job(filepath; kwargs...))
-function SingleCellProjections.load_csv(filepath::Union{String,TimestampedFilePath}; kwargs...)
+function SCP.load_csv(filepath::Union{String,TimestampedFilePath}; kwargs...)
 	filepath_job = checksummedfilepath_job(filepath)
 	create_job(Preprocess(load_csv), filepath_job; kwargs...)
 end

--- a/ext/MuonExt.jl
+++ b/ext/MuonExt.jl
@@ -2,7 +2,8 @@ module MuonExt
 
 using ReproducibleJobs
 using ReproducibleJobs: create_job, cached, prefetched, ChecksummedFilePath
-using SingleCellProjections
+import SingleCellProjections as SCP
+# using SingleCellProjections
 using SingleCellProjections.Impl: DataMatrixFunction, Mat, Var, Obs, table_to_compound_result, table_from_compound_result, checksummedfilepath_job, prefixed_ids_job, compute_size_job
 import .SingleCellProjections.SCPCore
 using DataFrames
@@ -113,7 +114,7 @@ function load_h5ad(::Obs, filepath; varm=nothing, varp=nothing, kwargs...)
 	end
 end
 
-function SingleCellProjections.load_h5ad(filepath; kwargs...)
+function SCP.load_h5ad(filepath; kwargs...)
 	if count(key->haskey(kwargs,key), (:layer, :obsm, :obsp, :varm, :varp)) > 1
 		throw(ArgumentError("At most one of layer, obsm, obsp, varm, varp can be specified."))
 	end
@@ -121,7 +122,7 @@ function SingleCellProjections.load_h5ad(filepath; kwargs...)
 	filepath_job = checksummedfilepath_job(filepath)
 	create_job(DataMatrixFunction(load_h5ad), filepath_job; kwargs...)
 end
-SingleCellProjections.load_h5ad(::Type{T}, filepath; kwargs...) where T = SingleCellProjections.load_h5ad(filepath; T, kwargs...)
+SCP.load_h5ad(::Type{T}, filepath; kwargs...) where T = SCP.load_h5ad(filepath; T, kwargs...)
 
 
 end

--- a/ext/TSneExt.jl
+++ b/ext/TSneExt.jl
@@ -2,7 +2,8 @@ module TSneExt
 
 using ReproducibleJobs
 using ReproducibleJobs: create_job, cached
-using SingleCellProjections
+import SingleCellProjections as SCP
+# using SingleCellProjections
 using SingleCellProjections.Impl: DataMatrixFunction, Projectable, Action, Eval, Projection, Mat, Var, Obs, get_job, prefixed_ids_job, find_nearest_neighbors_job, create_embed_points_job, InvMax
 import TSne
 
@@ -53,13 +54,13 @@ end
 
 
 function tsne(::Mat, data; kwargs...)
-	matrix_job = SingleCellProjections.get_matrix(data)
+	matrix_job = SCP.get_matrix(data)
 	create_job(Projectable(tsne), matrix_job; kwargs...)
 end
 tsne(::Obs, data; kwargs...) = get_job(Obs(), data)
 tsne(::Var, data; ndim, kwargs...) = prefixed_ids_job("id", "t-SNE ", ndim)
 
-function SingleCellProjections.tsne(args...; ndim=3, kwargs...)
+function SCP.tsne(args...; ndim=3, kwargs...)
 	create_job(DataMatrixFunction(tsne), args...; ndim, kwargs...)
 end
 

--- a/ext/TSneExt.jl
+++ b/ext/TSneExt.jl
@@ -3,7 +3,7 @@ module TSneExt
 using ReproducibleJobs
 using ReproducibleJobs: create_job, cached
 using SingleCellProjections
-using SingleCellProjections.Impl: DataMatrixFunction, Projectable, Action, Eval, Projection, Mat, Var, Obs, get_matrix_job, get_job, prefixed_ids_job, find_nearest_neighbors_job, create_embed_points_job, InvMax
+using SingleCellProjections.Impl: DataMatrixFunction, Projectable, Action, Eval, Projection, Mat, Var, Obs, get_job, prefixed_ids_job, find_nearest_neighbors_job, create_embed_points_job, InvMax
 import TSne
 
 # """
@@ -53,7 +53,7 @@ end
 
 
 function tsne(::Mat, data; kwargs...)
-	matrix_job = get_matrix_job(data)
+	matrix_job = SingleCellProjections.get_matrix(data)
 	create_job(Projectable(tsne), matrix_job; kwargs...)
 end
 tsne(::Obs, data; kwargs...) = get_job(Obs(), data)

--- a/ext/UMAPExt.jl
+++ b/ext/UMAPExt.jl
@@ -3,7 +3,7 @@ module UMAPExt
 using ReproducibleJobs
 using ReproducibleJobs: create_job, cached, TypeTag, Cache
 using SingleCellProjections
-using SingleCellProjections.Impl: DataMatrixFunction, Projectable, Action, Eval, Projection, Mat, Var, Obs, get_matrix_job, get_job, prefixed_ids_job
+using SingleCellProjections.Impl: DataMatrixFunction, Projectable, Action, Eval, Projection, Mat, Var, Obs, get_job, prefixed_ids_job
 
 using DataFrames
 
@@ -71,7 +71,7 @@ end
 
 
 function umap(::Mat, data; ndim, seed, kwargs...)
-	matrix_job = get_matrix_job(data)
+	matrix_job = SingleCellProjections.get_matrix(data)
 	create_job(Projectable(umap_impl), matrix_job; ndim, seed, kwargs...)
 end
 umap(::Obs, data; ndim, kwargs...) = get_job(Obs(), data)

--- a/ext/UMAPExt.jl
+++ b/ext/UMAPExt.jl
@@ -2,7 +2,8 @@ module UMAPExt
 
 using ReproducibleJobs
 using ReproducibleJobs: create_job, cached, TypeTag, Cache
-using SingleCellProjections
+import SingleCellProjections as SCP
+# using SingleCellProjections
 using SingleCellProjections.Impl: DataMatrixFunction, Projectable, Action, Eval, Projection, Mat, Var, Obs, get_job, prefixed_ids_job
 
 using DataFrames
@@ -71,14 +72,14 @@ end
 
 
 function umap(::Mat, data; ndim, seed, kwargs...)
-	matrix_job = SingleCellProjections.get_matrix(data)
+	matrix_job = SCP.get_matrix(data)
 	create_job(Projectable(umap_impl), matrix_job; ndim, seed, kwargs...)
 end
 umap(::Obs, data; ndim, kwargs...) = get_job(Obs(), data)
 umap(::Var, data; ndim, kwargs...) = prefixed_ids_job("id", "UMAP ", ndim)
 
 
-function SingleCellProjections.umap(data; ndim, seed=1234, kwargs...)
+function SCP.umap(data; ndim, seed=1234, kwargs...)
 	create_job(DataMatrixFunction(umap), data; ndim, seed, kwargs...)
 end
 

--- a/src/Impl/adjoint.jl
+++ b/src/Impl/adjoint.jl
@@ -3,10 +3,10 @@ adjoint_matrix_job(X) = create_job(LinearAlgebra.adjoint, X; __version=v"0.1.0")
 # TODO: Should we do unwrapping of adjoint(adjoint(X)) should probably be done as a late preprocessing step.
 function adjoint(::Mat, data)
 	if data.f == DataMatrixFunction(adjoint)
-		get_matrix_job(data.args[1]) # adjoint(adjoint(X)) == X
+		SCP.get_matrix(data.args[1]) # adjoint(adjoint(X)) == X
 	else
-		adjoint_matrix_job(get_matrix_job(data))
+		adjoint_matrix_job(SCP.get_matrix(data))
 	end
 end
-adjoint(::Var, data) = get_obs_job(data)
-adjoint(::Obs, data) = get_var_job(data)
+adjoint(::Var, data) = SCP.get_obs(data)
+adjoint(::Obs, data) = SCP.get_var(data)

--- a/src/Impl/annotate.jl
+++ b/src/Impl/annotate.jl
@@ -1,17 +1,17 @@
-annotate(::Mat, data; kwargs...) = get_matrix_job(data)
+annotate(::Mat, data; kwargs...) = SCP.get_matrix(data)
 function annotate(f::Union{Var,Obs}, data; kwargs...)
 	s = get_job(f, data)
 	df = get(kwargs, f isa Var ? :var : :obs, nothing)
 	df === nothing && return s
-	table_leftjoin_job(s, df)
+	SCP.table_leftjoin(s, df)
 end
 
 
 add_var_column(f::Union{Mat,Obs}, data, name, column) = get_job(f, data)
-add_var_column(::Var, data, name, column) = add_column_job(get_var_job(data), name, column)
+add_var_column(::Var, data, name, column) = SCP.add_column(SCP.get_var(data), name, column)
 
 add_obs_column(f::Union{Mat,Var}, data, name, column) = get_job(f, data)
-add_obs_column(::Obs, data, name, column) = add_column_job(get_obs_job(data), name, column)
+add_obs_column(::Obs, data, name, column) = SCP.add_column(SCP.get_obs(data), name, column)
 
 
 
@@ -24,45 +24,45 @@ counts_sum_impl_job(f, counts, ind; dims) =
 	create_job(SCPCore.counts_sum, f, counts, ind; dims, __version=v"0.1.0")
 
 
-var_counts_fraction(::Mat, counts, args...; kwargs...) = get_matrix_job(counts)
-var_counts_fraction(::Var, counts, args...; kwargs...) = get_var_job(counts)
+var_counts_fraction(::Mat, counts, args...; kwargs...) = SCP.get_matrix(counts)
+var_counts_fraction(::Var, counts, args...; kwargs...) = SCP.get_var(counts)
 function var_counts_fraction(::Obs, counts, col, sub_filter, tot_filter; project_ids)
-	var_job = get_var_job(counts)
+	var_job = SCP.get_var(counts)
 	sub_ind = prefetched(create_find_matching_ind_job(sub_filter, var_job; project_ids))
 	tot_ind = prefetched(create_find_matching_ind_job(tot_filter, var_job; project_ids))
-	values_job = cached(counts_fraction_impl_job(get_matrix_job(counts), sub_ind, tot_ind; dims=1))
-	add_column_job(get_obs_job(counts), col, values_job)
+	values_job = cached(counts_fraction_impl_job(SCP.get_matrix(counts), sub_ind, tot_ind; dims=1))
+	SCP.add_column(SCP.get_obs(counts), col, values_job)
 end
 
 
-var_counts_sum(::Mat, counts, args...; kwargs...) = get_matrix_job(counts)
-var_counts_sum(::Var, counts, args...; kwargs...) = get_var_job(counts)
+var_counts_sum(::Mat, counts, args...; kwargs...) = SCP.get_matrix(counts)
+var_counts_sum(::Var, counts, args...; kwargs...) = SCP.get_var(counts)
 function var_counts_sum(::Obs, counts, col, filter; project_ids, f=identity)
-	ind = prefetched(create_find_matching_ind_job(filter, get_var_job(counts); project_ids))
-	values_job = cached(counts_sum_impl_job(f, get_matrix_job(counts), ind; dims=1))
-	add_column_job(get_obs_job(counts), col, values_job)
+	ind = prefetched(create_find_matching_ind_job(filter, SCP.get_var(counts); project_ids))
+	values_job = cached(counts_sum_impl_job(f, SCP.get_matrix(counts), ind; dims=1))
+	SCP.add_column(SCP.get_obs(counts), col, values_job)
 end
 
 
 
 # TODO: Can we get better code reuse with the `var` functions above?
-obs_counts_fraction(::Mat, counts, args...; kwargs...) = get_matrix_job(counts)
+obs_counts_fraction(::Mat, counts, args...; kwargs...) = SCP.get_matrix(counts)
 function obs_counts_fraction(::Var, counts, col, sub_filter, tot_filter; project_ids)
-	obs_job = get_obs_job(counts)
+	obs_job = SCP.get_obs(counts)
 	sub_ind = prefetched(create_find_matching_ind_job(sub_filter, obs_job; project_ids))
 	tot_ind = prefetched(create_find_matching_ind_job(tot_filter, obs_job; project_ids))
 
-	values_job = cached(counts_fraction_impl_job(get_matrix_job(counts), sub_ind, tot_ind; dims=2))
-	add_column_job(get_var_job(counts), col, values_job)
+	values_job = cached(counts_fraction_impl_job(SCP.get_matrix(counts), sub_ind, tot_ind; dims=2))
+	SCP.add_column(SCP.get_var(counts), col, values_job)
 end
-obs_counts_fraction(::Obs, counts, args...; kwargs...) = get_obs_job(counts)
+obs_counts_fraction(::Obs, counts, args...; kwargs...) = SCP.get_obs(counts)
 
 
 # TODO: Can we get better code reuse with the `var` functions above?
-obs_counts_sum(::Mat, counts, args...; kwargs...) = get_matrix_job(counts)
+obs_counts_sum(::Mat, counts, args...; kwargs...) = SCP.get_matrix(counts)
 function obs_counts_sum(::Var, counts, col, filter; project_ids, f=identity)
-	ind = prefetched(create_find_matching_ind_job(filter, get_obs_job(counts); project_ids))
-	values_job = cached(counts_sum_impl_job(f, get_matrix_job(counts), ind; dims=2))
-	add_column_job(get_var_job(counts), col, values_job)
+	ind = prefetched(create_find_matching_ind_job(filter, SCP.get_obs(counts); project_ids))
+	values_job = cached(counts_sum_impl_job(f, SCP.get_matrix(counts), ind; dims=2))
+	SCP.add_column(SCP.get_var(counts), col, values_job)
 end
-obs_counts_sum(::Obs, counts, args...; kwargs...) = get_obs_job(counts)
+obs_counts_sum(::Obs, counts, args...; kwargs...) = SCP.get_obs(counts)

--- a/src/Impl/annotation_transfer.jl
+++ b/src/Impl/annotation_transfer.jl
@@ -32,8 +32,8 @@ update_name_job(old_name; kwargs...) =
 
 function transfer_annotation(::Preprocessing, base, new, covariate; k, weight_fun=InvMax(1e-12), kwargs...)
 	# TODO: Check that var agree
-	base_mat = get_matrix_job(base)
-	new_mat = get_matrix_job(new)
+	base_mat = SCP.get_matrix(base)
+	new_mat = SCP.get_matrix(new)
 
 	# TODO: reimplement without actually constructing dists as an intermediate representation
 
@@ -41,12 +41,12 @@ function transfer_annotation(::Preprocessing, base, new, covariate; k, weight_fu
 	# # Unwrap knn_job CompoundResult
 	# indices = cached(knn, "indices")
 	# dists = cached(knn, "distances")
-	# wadj = weighted_adjacency_matrix_job(weight_fun, indices, dists; NX=nobs_job(base))
+	# wadj = weighted_adjacency_matrix_job(weight_fun, indices, dists; NX=SCP.nobs(base))
 
 
 	knn_indices = find_nearest_neighbors_job(base_mat, new_mat; k)
 
-	obs = get_obs_job(base)
+	obs = SCP.get_obs(base)
 	annot, desc = setup_covariate_description(obs, covariate)
 	annot_name = fetched(_extract_name(annot))
 	annot_data = _extract_data_job(obs, annot)
@@ -57,8 +57,8 @@ function transfer_annotation(::Preprocessing, base, new, covariate; k, weight_fu
 	score = cached(t, "score")
 
 	# make into table
-	new_obs_ids = id_column_job(get_obs_job(new))
+	new_obs_ids = SCP.id_column(SCP.get_obs(new))
 	transferred_name = fetched(update_name_job(annot_name; kwargs...))
 	score_name = fetched(update_name_job(transferred_name; new_suffix="_score"))
-	table_hcat_job(new_obs_ids, create_table_job(transferred_name=>transferred, score_name=>score))
+	SCP.table_hcat(new_obs_ids, SCP.create_table(transferred_name=>transferred, score_name=>score))
 end

--- a/src/Impl/annotation_transfer.jl
+++ b/src/Impl/annotation_transfer.jl
@@ -62,6 +62,3 @@ function transfer_annotation(::Preprocessing, base, new, covariate; k, weight_fu
 	score_name = fetched(update_name_job(transferred_name; new_suffix="_score"))
 	table_hcat_job(new_obs_ids, create_table_job(transferred_name=>transferred, score_name=>score))
 end
-
-transfer_annotation_job(base, new, covariate; k, kwargs...) =
-	create_job(Preprocess(transfer_annotation), base, new, covariate; k, kwargs...)

--- a/src/Impl/blocks.jl
+++ b/src/Impl/blocks.jl
@@ -47,7 +47,7 @@ end
 
 blockify_matrix_job(A; kwargs...) = create_job(Preprocess{false}(blockify_matrix), A; kwargs...)
 
-blockify(::Mat, data; kwargs...) = blockify_matrix_job(get_matrix_job(data); kwargs...)
+blockify(::Mat, data; kwargs...) = blockify_matrix_job(SCP.get_matrix(data); kwargs...)
 blockify(f::Union{Var,Obs}, data; kwargs...) = get_job(f, data)
 
 blockify_job(data; kwargs...) = create_job(DataMatrixFunction(blockify), data; kwargs...)

--- a/src/Impl/datamatrixfunctions.jl
+++ b/src/Impl/datamatrixfunctions.jl
@@ -168,15 +168,9 @@ end
 # end
 
 
-get_matrix_job(x) = create_job(Preprocess(get_matrix), x)
-
-get_var_job(x) = create_job(Preprocess(get_var), x)
-
-get_obs_job(x) = create_job(Preprocess(get_obs), x)
-
-get_job(::Mat, x) = get_matrix_job(x)
-get_job(::Var, x) = get_var_job(x)
-get_job(::Obs, x) = get_obs_job(x)
+get_job(::Mat, x) = SCP.get_matrix(x)
+get_job(::Var, x) = SCP.get_var(x)
+get_job(::Obs, x) = SCP.get_obs(x)
 
 
 
@@ -240,9 +234,9 @@ end
 
 function project_onto_impl(d::DataMatrixFunction{F}, replacements, args...; kwargs...) where F
 	onto = create_job(d, args...; kwargs...) # recreate original spec...
-	matrix = create_project_job(get_matrix_job(onto), replacements...)
-	var = create_project_job(get_var_job(onto), replacements...)
-	obs = create_project_job(get_obs_job(onto), replacements...)
+	matrix = create_project_job(SCP.get_matrix(onto), replacements...)
+	var = create_project_job(SCP.get_var(onto), replacements...)
+	obs = create_project_job(SCP.get_obs(onto), replacements...)
 	create_datamatrix_job(matrix, var, obs)
 end
 

--- a/src/Impl/design.jl
+++ b/src/Impl/design.jl
@@ -5,17 +5,17 @@ detect_covariate_desc_job(values) = create_job(detect_covariate_desc, values; __
 
 
 # TODO: Move this to internal? It can be used in many places.
-_extract_data_job(table, column::String) = column_data_job(table, column) # Column in the table (typically obs)
+_extract_data_job(table, column::String) = SCP.column_data(table, column) # Column in the table (typically obs)
 function _extract_data_job(table, annot) # External annotation (DataFrame or spec)
-	ids_a = id_column_job(table)
-	ids_b = id_column_job(annot)
+	ids_a = SCP.id_column(table)
+	ids_b = SCP.id_column(annot)
 	ind_job = indexin_job(ids_a, ids_b; not_found=:nothing)
-	v = value_column_data_job(annot)
+	v = SCP.value_column_data(annot)
 	getindex_or_missing_job(v, ind_job) # The values of the annotation, reordered to match the order in table.
 end
 
 _extract_name(column::String) = column
-_extract_name(annot) = get_value_colname_job(annot)
+_extract_name(annot) = SCP.get_value_colname(annot)
 
 
 
@@ -176,11 +176,11 @@ has_centering_job(cov_descs) =
 
 function build_designmatrix_dm(::Mat, data, cov_data, cov_descs, ::Any; center, kwargs...)
 	@assert length(cov_data) == length(cov_descs)
-	obs = get_obs_job(data)
+	obs = SCP.get_obs(data)
 
 	cm = covariate_matrix_job.(cov_data, cov_descs; center, kwargs...)
 	if center
-		ispec = intercept_covariate_matrix_job(table_nrow_job(obs))
+		ispec = intercept_covariate_matrix_job(SCP.table_nrow(obs))
 		hcat_job(vcat(ispec, cm))
 	else
 		hcat_job(cm)
@@ -188,10 +188,10 @@ function build_designmatrix_dm(::Mat, data, cov_data, cov_descs, ::Any; center, 
 end
 function build_designmatrix_dm(::Obs, ::Any, ::Any, ::Any, cov_names; center, kwargs...)
 	center && (cov_names = vcat("Intercept", cov_names))
-	# create_table_job("covariate"=>vcat_job(cov_names...))
-	create_table_job("covariate"=>vcat_job(cov_names))
+	# SCP.create_table("covariate"=>vcat_job(cov_names...))
+	SCP.create_table("covariate"=>vcat_job(cov_names))
 end
-build_designmatrix_dm(::Var, data, ::Any, ::Any, ::Any; kwargs...) = get_obs_job(data) # Yes this is correct. (See note below regarding transposing)
+build_designmatrix_dm(::Var, data, ::Any, ::Any, ::Any; kwargs...) = SCP.get_obs(data) # Yes this is correct. (See note below regarding transposing)
 
 
 # This preprocessing step is needed so that the covariate representations are preprocessed
@@ -204,7 +204,7 @@ build_designmatrix_job(data, cov_data, cov_descs, cov_names; kwargs...) =
 
 
 function designmatrix(::Preprocessing, data, args...; center, kwargs...)
-	obs = get_obs_job(data)
+	obs = SCP.get_obs(data)
 	cov_annots, cov_descs = setup_covariate_descriptions(obs, args...)
 	cov_data = _extract_data_job.(Ref(obs), cov_annots)
 	center = center || fetched(has_centering_job(cov_descs))
@@ -217,6 +217,4 @@ end
 # Creates a DataMatrix with obs as var and covariates as obs
 # TODO: Consider transposing
 # data::DataMatrix, args are covariates (names, two-column DataFrames with IDs+Values, optionally in pairs with covariate descriptions), center::Bool
-designmatrix_job(data, args...; center=true, kwargs...) =
-	create_job(Preprocess(designmatrix), data, args...; center, kwargs...)
 

--- a/src/Impl/filter.jl
+++ b/src/Impl/filter.jl
@@ -1,6 +1,6 @@
 function subset_matrix(::Preprocessing, data; var_ids=nothing, obs_ids=nothing)
-	var_ind_args = var_ids === nothing ? (;) : (; var_ind=indexin_job(var_ids, id_column_job(get_var_job(data)); not_found=:error))
-	obs_ind_args = obs_ids === nothing ? (;) : (; obs_ind=indexin_job(obs_ids, id_column_job(get_obs_job(data)); not_found=:error))
+	var_ind_args = var_ids === nothing ? (;) : (; var_ind=indexin_job(var_ids, SCP.id_column(SCP.get_var(data)); not_found=:error))
+	obs_ind_args = obs_ids === nothing ? (;) : (; obs_ind=indexin_job(obs_ids, SCP.id_column(SCP.get_obs(data)); not_found=:error))
 	create_datamatrix_getindex_job(data; var_ind_args..., obs_ind_args...)
 end
 
@@ -19,8 +19,8 @@ function filter_matrix(::Preprocessing, data; fvar=nothing, fobs=nothing, projec
 	project_var_ids = @something(project_var_ids, :intersect)
 	project_obs_ids = @something(project_obs_ids, :no)
 
-	var_ind = create_find_matching_ind_job(fvar, get_var_job(data); project_ids=project_var_ids)
-	obs_ind = create_find_matching_ind_job(fobs, get_obs_job(data); project_ids=project_obs_ids)
+	var_ind = create_find_matching_ind_job(fvar, SCP.get_var(data); project_ids=project_var_ids)
+	obs_ind = create_find_matching_ind_job(fobs, SCP.get_obs(data); project_ids=project_obs_ids)
 
 	create_datamatrix_getindex_job(data; var_ind, obs_ind)
 end

--- a/src/Impl/internal.jl
+++ b/src/Impl/internal.jl
@@ -196,13 +196,9 @@ indexin_job(a, b; not_found=:error) = create_job(indexin_impl, a, b; not_found, 
 
 
 
-nvar_job(data) = table_nrow_job(get_var_job(data))
-
-nobs_job(data) = table_nrow_job(get_obs_job(data))
-
 
 # These are for situations were we cannot avoid using size on the materialized matrix.
-# Prefer nvar_job/nobs_job or other smart ways to get size when possible.
+# Prefer SCP.nvar/SCP.nobs or other smart ways to get size when possible.
 compute_size(X, dim) = size(X, dim)
 compute_size_job(X, dim) = create_job(compute_size, X, dim; __version=v"0.1.0")
 
@@ -227,19 +223,19 @@ function find_matching_ind(action::Action, f, df; project_ids::Symbol)
 
 		# subset the columns to only depend on those that are used
 		if k isa AbstractString
-			x = get_columns_job(df, k)
+			x = SCP.get_columns(df, k)
 			matching_ind = cached(find_matching_ind_impl_job(f, x))
 		elseif k isa AbstractVector
-			x = get_columns_job(df, k...)
+			x = SCP.get_columns(df, k...)
 			matching_ind = cached(find_matching_ind_impl_job(f, x))
 		elseif k isa Union{SpecRef, DataFrame}
 			# k is an "Annotation" - a DataFrame with an ID and a value column. Will be leftjoined and the function will be applied to the leftjoined vector with values.
 
 			# TODO: Share code with `_extract_data_job`?
-			ids_a = id_column_job(df)
-			ids_b = id_column_job(k)
+			ids_a = SCP.id_column(df)
+			ids_b = SCP.id_column(k)
 			ind_job = indexin_job(ids_a, ids_b; not_found=:nothing)
-			v = value_column_data_job(k)
+			v = SCP.value_column_data(k)
 			x = getindex_or_missing_job(v, ind_job) # The values of the annotation `k`, reordered to match the order in df.
 
 			matching_ind = cached(find_matching_ind_impl_job(last(f), x))
@@ -257,7 +253,7 @@ function find_matching_ind(action::Action, f, df; project_ids::Symbol)
 		return Colon()
 	else
 		# We need to remap the indices, going through IDs
-		ids = id_column_job(df)
+		ids = SCP.id_column(df)
 		ids2 = action(ids) # IDs from projected dataset
 
 		cond = isequal_job(ids, ids2)
@@ -385,13 +381,13 @@ end
 
 
 datamatrix_getindex(::Mat, data; kwargs...) =
-	create_matrix_getindex_job(get_matrix_job(data); kwargs...)
+	create_matrix_getindex_job(SCP.get_matrix(data); kwargs...)
 function datamatrix_getindex(::Var, data; var_ind=nothing, kwargs...)
-	var = get_var_job(data)
+	var = SCP.get_var(data)
 	var_ind === nothing ? var : table_getindex_job(var, var_ind)
 end
 function datamatrix_getindex(::Obs, data; obs_ind=nothing, kwargs...)
-	obs = get_obs_job(data)
+	obs = SCP.get_obs(data)
 	obs_ind === nothing ? obs : table_getindex_job(obs, obs_ind)
 end
 
@@ -467,7 +463,7 @@ get_matrix_col_job(matrix, ind) =
 prefixed_id_values(prefix::String, n) = string.(prefix, 1:n)
 function prefixed_ids(::Preprocessing, col::String, prefix, n)
 	col_data = create_job(prefixed_id_values, prefix, n; __version=v"0.1.0")
-	create_table_job(col=>col_data)
+	SCP.create_table(col=>col_data)
 end
 prefixed_ids_job(col, prefix, n) =
 	create_job(Preprocess(prefixed_ids), col, prefix, n)

--- a/src/Impl/load.jl
+++ b/src/Impl/load.jl
@@ -130,16 +130,9 @@ metadata_to_hblock_ranges_job(metadata) =
 	create_job(metadata_to_hblock_ranges, metadata; __version=v"0.0.1")
 
 
-# Delegators: a single filename spec means the matrix, features and barcodes all come from the same
-# file (the .h5 case), so all three components read from `filename_specs`. This keeps the .h5 job
-# graph (and hashes) identical to before.
-load_counts(f::Union{Mat,Var}, filename_specs; kwargs...) =
-	load_counts(f, filename_specs, filename_specs, filename_specs; kwargs...)
-load_counts(f::Obs, filename_specs; kwargs...) =
-	load_counts(f, filename_specs, filename_specs, filename_specs; kwargs...)
-
-
-function load_counts(f::Union{Mat,Var}, matrix_specs, feature_specs, barcode_specs; sample_names, prefilter, extra_id_cols, kwargs...)
+function load_counts(f::Union{Mat,Var}, matrix_specs;
+                     feature_specs = matrix_specs, # since features can be loaded from .h5 files
+                     sample_names, prefilter, extra_id_cols, kwargs...)
 	sample_var_specs = load_var_job.(feature_specs)
 	var_job = combine_var_job(sample_var_specs; prefilter, extra_id_cols)
 
@@ -158,5 +151,8 @@ function load_counts(f::Union{Mat,Var}, matrix_specs, feature_specs, barcode_spe
 		end
 	end
 end
-load_counts(::Obs, matrix_specs, feature_specs, barcode_specs; sample_names, prefilter, extra_id_cols, kwargs...) =
+function load_counts(::Obs, matrix_specs;
+                     barcode_specs = matrix_specs, # since barcodes can be loaded from .h5 files
+                     sample_names, kwargs...)
 	combine_obs_job(barcode_specs, sample_names)
+end

--- a/src/Impl/load.jl
+++ b/src/Impl/load.jl
@@ -25,7 +25,7 @@ vcat_tables_job(tables; kwargs...) = create_job(vcat_tables, tables; kwargs..., 
 function combine_obs(::Preprocessing, filenames, sample_names)
 	sample_barcodes_specs = load_barcodes_job.(filenames)
 	sample_id_specs = combine_vectors_job.(sample_names, '_', sample_barcodes_specs)
-	sample_obs_specs = create_table_job.("cell_id" .=> sample_id_specs,
+	sample_obs_specs = SCP.create_table.("cell_id" .=> sample_id_specs,
 	                                      "sample_name" .=> sample_names,
 	                                      "barcode" .=> sample_barcodes_specs)
 	combined = vcat_tables_job(sample_obs_specs)

--- a/src/Impl/load.jl
+++ b/src/Impl/load.jl
@@ -130,24 +130,33 @@ metadata_to_hblock_ranges_job(metadata) =
 	create_job(metadata_to_hblock_ranges, metadata; __version=v"0.0.1")
 
 
-function load_counts(f::Union{Mat,Var}, filename_specs; sample_names, prefilter, extra_id_cols, kwargs...)
-	sample_var_specs = load_var_job.(filename_specs)
+# Delegators: a single filename spec means the matrix, features and barcodes all come from the same
+# file (the .h5 case), so all three components read from `filename_specs`. This keeps the .h5 job
+# graph (and hashes) identical to before.
+load_counts(f::Union{Mat,Var}, filename_specs; kwargs...) =
+	load_counts(f, filename_specs, filename_specs, filename_specs; kwargs...)
+load_counts(f::Obs, filename_specs; kwargs...) =
+	load_counts(f, filename_specs, filename_specs, filename_specs; kwargs...)
+
+
+function load_counts(f::Union{Mat,Var}, matrix_specs, feature_specs, barcode_specs; sample_names, prefilter, extra_id_cols, kwargs...)
+	sample_var_specs = load_var_job.(feature_specs)
 	var_job = combine_var_job(sample_var_specs; prefilter, extra_id_cols)
 
 	if f isa Var
 		return var_job
 	else # if f isa Mat
 		var_ind_specs = prefetched.(sample_var_indices_job.(sample_var_specs, var_job; extra_id_cols))
-		sample_specs = load_sample_matrix_job.(filename_specs, var_ind_specs)
+		sample_specs = load_sample_matrix_job.(matrix_specs, var_ind_specs)
 
 		if length(sample_specs)	== 1
 			return only(sample_specs)
 		else
-			metadata_specs = load_sample_matrix_metadata_job.(filename_specs, var_ind_specs)
+			metadata_specs = load_sample_matrix_metadata_job.(matrix_specs, var_ind_specs)
 			ranges = fetched(metadata_to_hblock_ranges_job(vcat_job(metadata_specs)))
 			return hblock_job(sample_specs, ranges)
 		end
 	end
 end
-load_counts(::Obs, filename_specs; sample_names, prefilter, extra_id_cols, kwargs...) =
-	combine_obs_job(filename_specs, sample_names)
+load_counts(::Obs, matrix_specs, feature_specs, barcode_specs; sample_names, prefilter, extra_id_cols, kwargs...) =
+	combine_obs_job(barcode_specs, sample_names)

--- a/src/Impl/local_outlier_factor.jl
+++ b/src/Impl/local_outlier_factor.jl
@@ -47,11 +47,11 @@ end
 
 
 function local_outlier_factor_pre(::Preprocessing, data, full; k, col::String)
-	mat = get_matrix_job(data)
-	full_mat = get_matrix_job(full)
+	mat = SCP.get_matrix(data)
+	full_mat = SCP.get_matrix(full)
 
-	obs_ids = id_column_job(get_obs_job(data)) # TODO: check that this is equal to `id_column_job(get_obs_job(full))`
+	obs_ids = SCP.id_column(SCP.get_obs(data)) # TODO: check that this is equal to `SCP.id_column(SCP.get_obs(full))`
 
 	lof_job = create_job(Projectable(local_outlier_factor), mat, full_mat; k)
-	table_hcat_job(obs_ids, create_table_job(col=>lof_job))
+	SCP.table_hcat(obs_ids, SCP.create_table(col=>lof_job))
 end

--- a/src/Impl/local_outlier_factor.jl
+++ b/src/Impl/local_outlier_factor.jl
@@ -55,7 +55,3 @@ function local_outlier_factor_pre(::Preprocessing, data, full; k, col::String)
 	lof_job = create_job(Projectable(local_outlier_factor), mat, full_mat; k)
 	table_hcat_job(obs_ids, create_table_job(col=>lof_job))
 end
-
-
-local_outlier_factor_job(data, full; k=10, col="LOF") =
-	create_job(Preprocess(local_outlier_factor_pre), data, full; k, col)

--- a/src/Impl/matrix_arithmetic.jl
+++ b/src/Impl/matrix_arithmetic.jl
@@ -9,9 +9,9 @@ matrix_product_impl_job(args...) =
 	create_job(SCPCore.matrixproduct, args...; __version=v"0.1.1")
 
 # TODO: check that the inner var/obs IDs match!
-matrix_product(::Mat, args...) = matrix_product_impl_job(_map_value.(get_matrix_job, args)...)
-matrix_product(::Var, args...) = get_var_job(_get_value(first(args)))
-matrix_product(::Obs, args...) = get_obs_job(_get_value(last(args)))
+matrix_product(::Mat, args...) = matrix_product_impl_job(_map_value.(SCP.get_matrix, args)...)
+matrix_product(::Var, args...) = SCP.get_var(_get_value(first(args)))
+matrix_product(::Obs, args...) = SCP.get_obs(_get_value(last(args)))
 
 function matrix_product_job(arg1, args...)
 	create_job(DataMatrixFunction(matrix_product), arg1, args...)
@@ -22,9 +22,9 @@ matrix_sum_impl_job(args...) =
 	create_job(SCPCore.matrixsum, args...; __version=v"0.1.1")
 
 # TODO: check that the inner var/obs IDs match!
-matrix_sum(::Mat, args...) = matrix_sum_impl_job(_map_value.(get_matrix_job, args)...)
-matrix_sum(::Var, args...) = get_var_job(_get_value(first(args)))
-matrix_sum(::Obs, args...) = get_obs_job(_get_value(first(args)))
+matrix_sum(::Mat, args...) = matrix_sum_impl_job(_map_value.(SCP.get_matrix, args)...)
+matrix_sum(::Var, args...) = SCP.get_var(_get_value(first(args)))
+matrix_sum(::Obs, args...) = SCP.get_obs(_get_value(first(args)))
 
 function matrix_sum_job(arg1, args...)
 	create_job(DataMatrixFunction(matrix_sum), arg1, args...)

--- a/src/Impl/normalize.jl
+++ b/src/Impl/normalize.jl
@@ -6,7 +6,7 @@ negative_regression_matrix_impl_job(data, dm; kwargs...) =
 
 function negative_regression_matrix(::Mat, data, dm; kwargs...)
 	# TODO: check that data and dm IDs match
-	negative_regression_matrix_impl_job(get_matrix_job(data), get_matrix_job(dm); kwargs...)
+	negative_regression_matrix_impl_job(SCP.get_matrix(data), SCP.get_matrix(dm); kwargs...)
 end
 negative_regression_matrix(::Var, data, dm; kwargs...) = get_job(Var(), data)
 negative_regression_matrix(::Obs, data, dm; kwargs...) = get_job(Obs(), dm)
@@ -30,7 +30,7 @@ function normalize_matrix(::Preprocessing, data, args...; center=true,
 		annotate_std = std_col !== nothing,
 		annotate_relative_std = relative_std_col !== nothing,
 		kwargs...)
-	dm = designmatrix_job(data, args...; center)
+	dm = SCP.designmatrix(data, args...; center)
 	negβT = negative_regression_matrix_job(data, dm; kwargs...)
 	dmT = SCP.transpose(dm)
 	normalized = matrix_sum_job(:A=>data, matrix_product_job(Symbol("(-β)")=>negβT, :X=>dmT))

--- a/src/Impl/pseudobulk.jl
+++ b/src/Impl/pseudobulk.jl
@@ -226,8 +226,6 @@ function pseudobulk(::Preprocessing, data, obs_covariate1, obs_covariates...; ne
 end
 
 
-pseudobulk_job(data, obs_covariate1, obs_covariates...; kwargs...) =
-	create_job(Preprocess(pseudobulk), data, obs_covariate1, obs_covariates...; kwargs...)
 
 
 
@@ -329,5 +327,3 @@ function population_matrix(::Preprocessing, obs, obs_covariate1, obs_covariates.
 end
 
 
-population_matrix_job(obs, obs_covariate1, obs_covariates...; kwargs...) =
-	create_job(Preprocess(population_matrix), obs, obs_covariate1, obs_covariates...; kwargs...)

--- a/src/Impl/pseudobulk.jl
+++ b/src/Impl/pseudobulk.jl
@@ -64,7 +64,7 @@ function pseudobulk_table_impl(::Preprocessing, categories, basenames, n_categor
 	reverse!(inner)
 
 	pb_cols = (name=>repeat_job(c; outer=outer[i], inner=extra_inner*inner[i]) for (i,(name,c)) in enumerate(zip(basenames, categories)))
-	create_table_job(pb_cols...)
+	SCP.create_table(pb_cols...)
 end
 
 function pseudobulk_table(action::Action, categories, basenames; do_project::Bool, kwargs...)
@@ -97,7 +97,7 @@ function pseudobulk_dm(::Mat, data, obs_cov_categories, obs_cov_ind, ::Any;
 	linear_ind_job = pseudobulk_linear_indices_job(cov_ind, n_categories)
 
 	n_combinations = prefetched(prod_job(n_categories))
-	mat = create_job(pseudobulk_mat, get_matrix_job(data), linear_ind_job, n_combinations; __version=v"0.1.0")
+	mat = create_job(pseudobulk_mat, SCP.get_matrix(data), linear_ind_job, n_combinations; __version=v"0.1.0")
 
 	# reshape if needed
 	if new_var_cov_categories !== nothing
@@ -113,12 +113,12 @@ function pseudobulk_dm(::Var, data, args...;
                        delim,
                        var_id_colname = nothing,
                        kwargs...)
-	var = get_var_job(data)
+	var = SCP.get_var(data)
 	# Standard case, we just keep the same variables
 	new_var_cov_categories === nothing && return var
 
 	# Table for the new covariates, already repeated to match number of variables
-	extra_inner = fetched(table_nrow_job(var))
+	extra_inner = fetched(SCP.table_nrow(var))
 	pb_table_job = pseudobulk_table_job(new_var_cov_categories, new_var_cov_basenames; do_project=false, extra_inner)
 
 	# Repeat the existing var table
@@ -126,11 +126,11 @@ function pseudobulk_dm(::Var, data, args...;
 	var = repeat_columns_job(var; outer=n_new_var_combinations)
 
 
-	id_table = table_hcat_job(id_column_job(var), pb_table_job)
+	id_table = SCP.table_hcat(SCP.id_column(var), pb_table_job)
 	id_values = combine_column_values_job(id_table; delim)
-	var_id_colname = @something var_id_colname fetched(join_job(get_colnames_job(id_table), delim))
+	var_id_colname = @something var_id_colname fetched(join_job(SCP.get_colnames(id_table), delim))
 
-	table_hcat_job(create_table_job(var_id_colname=>id_values),
+	SCP.table_hcat(SCP.create_table(var_id_colname=>id_values),
 	                var,
 	                pb_table_job)
 end
@@ -140,8 +140,8 @@ function pseudobulk_dm(::Obs, data, obs_cov_categories, ::Any, obs_cov_basenames
 	if length(obs_cov_categories)>1
 		# Add ID column if we need it. Otherwise reuse the name of the single covariate.
 		id_values = combine_column_values_job(pb_table_job; delim)
-		obs_id_colname = @something obs_id_colname fetched(join_job(get_colnames_job(pb_table_job), delim))
-		pb_table_job = table_hcat_job(create_table_job(obs_id_colname=>id_values), pb_table_job)
+		obs_id_colname = @something obs_id_colname fetched(join_job(SCP.get_colnames(pb_table_job), delim))
+		pb_table_job = SCP.table_hcat(SCP.create_table(obs_id_colname=>id_values), pb_table_job)
 	end
 
 	pb_table_job
@@ -190,7 +190,7 @@ end
 
 
 function pseudobulk(::Preprocessing, data, obs_covariate1, obs_covariates...; new_var_covariates=nothing, delim=nothing, kwargs...)
-	obs = get_obs_job(data)
+	obs = SCP.get_obs(data)
 
 	# obs_cov_annots, obs_cov_descs = setup_pseudobulk_covariates(obs_covariate1, obs_covariates...) # Something like this for TwoGroup support
 	obs_cov_annots = setup_pseudobulk_covariates(obs_covariate1, obs_covariates...)
@@ -276,8 +276,8 @@ function population_matrix_dm(::Var, args...;
 	if length(new_var_cov_categories)>1
 		# Add ID column if we need it. Otherwise reuse the name of the single covariate.
 		id_values = combine_column_values_job(pb_table_job; delim)
-		var_id_colname = @something var_id_colname fetched(join_job(get_colnames_job(pb_table_job), delim))
-		pb_table_job = table_hcat_job(create_table_job(var_id_colname=>id_values), pb_table_job)
+		var_id_colname = @something var_id_colname fetched(join_job(SCP.get_colnames(pb_table_job), delim))
+		pb_table_job = SCP.table_hcat(SCP.create_table(var_id_colname=>id_values), pb_table_job)
 	end
 	pb_table_job
 end
@@ -287,8 +287,8 @@ function population_matrix_dm(::Obs, obs_cov_categories, ::Any, obs_cov_basename
 	if length(obs_cov_categories)>1
 		# Add ID column if we need it. Otherwise reuse the name of the single covariate.
 		id_values = combine_column_values_job(pb_table_job; delim)
-		obs_id_colname = @something obs_id_colname fetched(join_job(get_colnames_job(pb_table_job), delim))
-		pb_table_job = table_hcat_job(create_table_job(obs_id_colname=>id_values), pb_table_job)
+		obs_id_colname = @something obs_id_colname fetched(join_job(SCP.get_colnames(pb_table_job), delim))
+		pb_table_job = SCP.table_hcat(SCP.create_table(obs_id_colname=>id_values), pb_table_job)
 	end
 	pb_table_job
 end

--- a/src/Impl/reduce.jl
+++ b/src/Impl/reduce.jl
@@ -1,7 +1,7 @@
 function actual_nsv_pr(::Action, data, nsv)
 	# NB: nsv is determined completely by the base case, so we do not project
-	P = nvar_job(data)
-	N = nobs_job(data)
+	P = SCP.nvar(data)
+	N = SCP.nobs(data)
 	create_job(min, nsv, P, N; __version=v"0.1.0")
 end
 actual_nsv_job(data, nsv) = create_job(Projectable(actual_nsv_pr), data, nsv)
@@ -52,7 +52,7 @@ end
 
 function svd(::Mat, data; nsv, kwargs...)
 	nsv = fetched(actual_nsv_job(data, nsv))
-	create_job(Projectable(svd_pr), get_matrix_job(data); nsv, kwargs...)
+	create_job(Projectable(svd_pr), SCP.get_matrix(data); nsv, kwargs...)
 end
 svd(f::Union{Var,Obs}, data; kwargs...) = get_job(f, data)
 
@@ -81,7 +81,7 @@ pca_pre(::Preprocessing, matrix; kwargs...) =
 
 function pca(::Mat, data; nsv, kwargs...)
 	nsv = fetched(actual_nsv_job(data, nsv))
-	create_job(Preprocess(pca_pre), get_matrix_job(data); nsv, kwargs...)
+	create_job(Preprocess(pca_pre), SCP.get_matrix(data); nsv, kwargs...)
 end
 function pca(::Var, data; nsv, kwargs...)
 	nsv = fetched(actual_nsv_job(data, nsv))
@@ -97,7 +97,7 @@ end
 
 function loadings(::Mat, data; nsv, kwargs...)
 	nsv = fetched(actual_nsv_job(data, nsv))
-	create_job(Projectable(loadings_pr), get_matrix_job(data); nsv, kwargs...)
+	create_job(Projectable(loadings_pr), SCP.get_matrix(data); nsv, kwargs...)
 end
 loadings(::Var, data; kwargs...) = get_job(Var(), data)
 function loadings(::Obs, data; nsv, kwargs...)
@@ -196,7 +196,7 @@ end
 
 
 function force_layout(::Mat, data; kwargs...)
-	matrix_job = get_matrix_job(data)
+	matrix_job = SCP.get_matrix(data)
 	create_job(Projectable(force_layout), matrix_job; kwargs...)
 end
 force_layout(::Obs, data; kwargs...) = get_job(Obs(), data)

--- a/src/Impl/signatures.jl
+++ b/src/Impl/signatures.jl
@@ -18,6 +18,3 @@ function signature_pre(::Preprocessing, data, var_filter, out_col_name; loadings
 	table = get_columns_job(annot, fetched(get_id_colname_job(annot)), extra_cols...)
 	table_hcat_job(table, create_table_job(out_col_name=>pc1))
 end
-
-signature_job(data, var_filter, out_col_name; kwargs...) =
-	create_job(Preprocess(signature_pre), data, var_filter, out_col_name; kwargs...)

--- a/src/Impl/signatures.jl
+++ b/src/Impl/signatures.jl
@@ -7,14 +7,14 @@ function signature_pre(::Preprocessing, data, var_filter, out_col_name; loadings
 	if loadings
 		reduced = SCP.loadings(data; svd_kwargs...)
 		pc1 = get_matrix_col_job(SCP.get_matrix(reduced), 1)
-		annot = get_var_job(reduced)
+		annot = SCP.get_var(reduced)
 	else
 		reduced = SCP.pca(data; svd_kwargs...)
 		pc1 = get_matrix_row_job(SCP.get_matrix(reduced), 1)
-		annot = get_obs_job(reduced)
+		annot = SCP.get_obs(reduced)
 	end
 
 	extra_cols isa Union{Symbol,<:AbstractString} && (extra_cols = (extra_cols,)) # for splatting convenience
-	table = get_columns_job(annot, fetched(get_id_colname_job(annot)), extra_cols...)
-	table_hcat_job(table, create_table_job(out_col_name=>pc1))
+	table = SCP.get_columns(annot, fetched(SCP.get_id_colname(annot)), extra_cols...)
+	SCP.table_hcat(table, SCP.create_table(out_col_name=>pc1))
 end

--- a/src/Impl/statistical_tests.jl
+++ b/src/Impl/statistical_tests.jl
@@ -36,7 +36,7 @@ function _filter_missing_obs(data, h::Tuple)
 
 	# Handle missing values
 	skip_missing_cols = []
-	obs = get_obs_job(data)
+	obs = SCP.get_obs(data)
 
 	for a in h
 		if a isa Pair
@@ -88,19 +88,19 @@ function ftest(::Preprocessing, data, h1; h0=(), center=true, max_categories=not
 	extra_kwargs = max_categories === nothing ? (;) : (; max_categories)
 
 	# Hmm. We want h1 to be mean-zero (if center=true), but we don't want the intercept column.
-	h1_design = designmatrix_job(data, h1...; center=false, extra_kwargs...)
-	h0_design = designmatrix_job(data, h0...; center, extra_kwargs...)
+	h1_design = SCP.designmatrix(data, h1...; center=false, extra_kwargs...)
+	h0_design = SCP.designmatrix(data, h0...; center, extra_kwargs...)
 
-	matrix = get_matrix_job(data)
+	matrix = SCP.get_matrix(data)
 
-	var = get_var_job(data)
-	table_var = id_column_job(var)
+	var = SCP.get_var(data)
+	table_var = SCP.id_column(var)
 	if var_cols !== nothing
 		var_cols = _splattable(var_cols)
-		table_var = table_hcat_job(table_var, get_columns_job(var, var_cols...))
+		table_var = SCP.table_hcat(table_var, SCP.get_columns(var, var_cols...))
 	end
 
-	ftest_table_job(matrix, table_var, get_matrix_job(h1_design), get_matrix_job(h0_design); do_sort)
+	ftest_table_job(matrix, table_var, SCP.get_matrix(h1_design), SCP.get_matrix(h0_design); do_sort)
 end
 
 
@@ -144,7 +144,7 @@ function ttest(::Preprocessing, data, h1; h0=(), center=true, max_categories=not
 	# Handle missing values
 	data = _filter_missing_obs(data; h1=_splattable(h1), h0, h1_missing, h0_missing)
 
-	obs = get_obs_job(data)
+	obs = SCP.get_obs(data)
 
 
 	extra_kwargs = max_categories === nothing ? (;) : (; max_categories)
@@ -160,23 +160,23 @@ function ttest(::Preprocessing, data, h1; h0=(), center=true, max_categories=not
 	end
 
 
-	h0_design = designmatrix_job(data, h0...; center, extra_kwargs...)
+	h0_design = SCP.designmatrix(data, h0...; center, extra_kwargs...)
 
 	h1_cov_data = _extract_data_job(obs, h1_cov_annot)
 	ms = mean_and_scale_job(h1_cov_data, h1_cov_desc; center)
 	h1_scale = fetched(getindex_job(ms, 2))
 	h1_design_mat = covariate_matrix_job(h1_cov_data, h1_cov_desc; center) # center affects this column, but we don't get an intercept
 
-	matrix = get_matrix_job(data)
+	matrix = SCP.get_matrix(data)
 
-	var = get_var_job(data)
-	table_var = id_column_job(var)
+	var = SCP.get_var(data)
+	table_var = SCP.id_column(var)
 	if var_cols !== nothing
 		var_cols = _splattable(var_cols)
-		table_var = table_hcat_job(table_var, get_columns_job(var, var_cols...))
+		table_var = SCP.table_hcat(table_var, SCP.get_columns(var, var_cols...))
 	end
 
-	ttest_table_job(matrix, table_var, h1_design_mat, h1_scale, get_matrix_job(h0_design); do_sort)
+	ttest_table_job(matrix, table_var, h1_design_mat, h1_scale, SCP.get_matrix(h0_design); do_sort)
 end
 
 

--- a/src/Impl/statistical_tests.jl
+++ b/src/Impl/statistical_tests.jl
@@ -104,8 +104,6 @@ function ftest(::Preprocessing, data, h1; h0=(), center=true, max_categories=not
 end
 
 
-ftest_job(data, h1; kwargs...) =
-	create_job(Preprocess(ftest), data, h1; kwargs...)
 
 
 
@@ -183,5 +181,3 @@ end
 
 
 
-ttest_job(data, h1; kwargs...) =
-	create_job(Preprocess(ttest), data, h1; kwargs...)

--- a/src/Impl/sum_squared.jl
+++ b/src/Impl/sum_squared.jl
@@ -14,27 +14,21 @@ function compute_variance(action::Action, X; assume_centered::Bool, col="varianc
 	# confirm the data is mean-centered. `false` is not supported.
 	assume_centered || throw(ArgumentError("assume_centered must be `true`: Consider using `normalize_matrix` to compute variance/std/relative_std."))
 	project == :yes && (X = action(X))
-	matrix = get_matrix_job(X)
+	matrix = SCP.get_matrix(X)
 	s2 = row_sum_squared_job(matrix)
-	n = fetched(nobs_job(X))
+	n = fetched(SCP.nobs(X))
 	values = cached(sum_squared_to_var_job(s2, n))
-	table_hcat_job(id_column_job(get_var_job(X)), create_table_job(col => values))
+	SCP.table_hcat(SCP.id_column(SCP.get_var(X)), SCP.create_table(col => values))
 end
-
-variance_job(X; kwargs...) = create_job(Projectable(compute_variance), X; kwargs...)
 
 
 function compute_std(::Preprocessing, X; assume_centered::Bool, col="std", project=:no)
-	transform_annotation_job(sqrt, variance_job(X; assume_centered, project); new_name=col)
+	SCP.transform_annotation(sqrt, SCP.variance(X; assume_centered, project); new_name=col)
 end
-
-std_job(X; kwargs...) = create_job(Preprocess(compute_std), X; kwargs...)
 
 
 function compute_relative_std(::Preprocessing, X; assume_centered::Bool, col="relative_std", project=:no)
-	std_table = std_job(X; assume_centered, project)
-	max_std = prefetched(apply_job(maximum, value_column_data_job(std_table)))
-	transform_annotation_job(Base.Fix2(/, max_std), std_table; new_name=col)
+	std_table = SCP.std(X; assume_centered, project)
+	max_std = prefetched(apply_job(maximum, SCP.value_column_data(std_table)))
+	SCP.transform_annotation(Base.Fix2(/, max_std), std_table; new_name=col)
 end
-
-relative_std_job(X; kwargs...) = create_job(Preprocess(compute_relative_std), X; kwargs...)

--- a/src/Impl/tables.jl
+++ b/src/Impl/tables.jl
@@ -1,6 +1,5 @@
 # NB: Column names here are fixed and expected to be strings.
 create_table(args::Pair{String,<:Any}...) = DataFrame(args...; copycols=false)
-create_table_job(args...) = create_job(create_table, args...; __version=v"0.1.0")
 
 is_create_table(x::SpecRef) = x.f == create_table
 is_create_table(::Any) = false
@@ -12,7 +11,7 @@ table_to_compound_result(table) = CompoundResult(; pairs(eachcol(table))...)
 # With known colnames
 function table_from_compound_result(compound_result, colnames)
 	cols = (name=>cached(compound_result, name) for name in colnames)
-	create_table_job(cols...)
+	SCP.create_table(cols...)
 end
 
 table_from_compound_result_pre(::Preprocessing, compound_result, colnames) =
@@ -64,17 +63,9 @@ function get_colnames(::Preprocessing{E}, table, args...; kwargs...) where E
 	end
 end
 
-get_colnames_job(table; kwargs...) = create_job(Preprocess(get_colnames), table; kwargs...)
-get_colnames_job(table, ind::Int; kwargs...) = create_job(Preprocess(get_colnames), table, ind; kwargs...)
-
-
-
 
 # Should add another layer of Preprocessing so that we see `get_id_colname` when forwarding Specs one step at a time?
-get_id_colname_job(table) = create_job(Preprocess(get_colnames), table, 1)
-
 # Should add another layer of Preprocessing so that we see `get_value_colname` when forwarding Specs one step at a time?
-get_value_colname_job(table) = create_job(Preprocess(get_colnames), table, 2; require_n_cols=2)
 
 
 
@@ -96,23 +87,21 @@ function get_columns(::Preprocessing{E}, table, colnames...; kwargs...) where E
 	if is_create_table(table)
 		_check_ncol(table; kwargs...)
 		ind = _colnames_to_colind(table, colnames...)
-		create_table_job(table.args[ind]...)
+		SCP.create_table(table.args[ind]...)
 	elseif E
 		create_job(Preprocess{false}(get_columns), table, colnames...; kwargs...)
 	else
 		create_job(get_columns_fallback, table, colnames...; kwargs..., __version=v"0.1.0")
 	end
 end
-get_columns_job(table, colname1, colnames...; kwargs...) = create_job(Preprocess(get_columns), table, colname1, colnames...; kwargs...)
 
 
 
-id_column(::Preprocessing, table) = get_columns_job(table, 1)
-id_column_job(table) = create_job(Preprocess(id_column), table)
+id_column(::Preprocessing, table) = SCP.get_columns(table, 1)
 
-value_column(::Preprocessing, table) = get_columns_job(table, 2; require_n_cols=2)
+value_column(::Preprocessing, table) = SCP.get_columns(table, 2; require_n_cols=2)
 
-annotation(::Preprocessing, table, colname) = get_columns_job(table, fetched(get_id_colname_job(table)), colname) # If we add support for mixed column indexing, this could be (1, colname)
+annotation(::Preprocessing, table, colname) = SCP.get_columns(table, fetched(SCP.get_id_colname(table)), colname) # If we add support for mixed column indexing, this could be (1, colname)
 
 
 
@@ -138,22 +127,19 @@ function column_data(::Preprocessing{E}, table, col; kwargs...) where E
 		create_job(column_data_fallback, table, col; kwargs..., __version=v"0.1.0")
 	end
 end
-column_data_job(table, col; kwargs...) = create_job(Preprocess(column_data), table, col; kwargs...)
 
 
 
 
-id_column_data(::Preprocessing, table) = column_data_job(table, 1)
+id_column_data(::Preprocessing, table) = SCP.column_data(table, 1)
 
-value_column_data(::Preprocessing, table) = column_data_job(table, 2; require_n_cols=2)
-value_column_data_job(table) = create_job(Preprocess(value_column_data), table)
+value_column_data(::Preprocessing, table) = SCP.column_data(table, 2; require_n_cols=2)
 
 
 
 
 
-table_nrow(::Preprocessing, table) = length_job(column_data_job(table,1))
-table_nrow_job(table) = create_job(Preprocess(table_nrow), table)
+table_nrow(::Preprocessing, table) = length_job(SCP.column_data(table,1))
 
 
 
@@ -179,10 +165,10 @@ function _add_column_validated(table, name, column)
 		throw(ArgumentError("A column with the name \"$name\" already exists."))
 	end
 
-	result = create_table_job(table.args..., name=>column)
+	result = SCP.create_table(table.args..., name=>column)
 
 	# Check that the length of the new column matches the old
-	n1 = table_nrow_job(table)
+	n1 = SCP.table_nrow(table)
 	n2 = length_job(column)
 	cond = isequal_job(n1, n2)
 	ifelse_pr_job(cond, result, _add_column_length_error_job(n1,n2,name))
@@ -198,7 +184,6 @@ function add_column(::Preprocessing{E}, table, name, column) where E
 		create_job(add_column_fallback, table, name, column; __version=v"0.1.0")
 	end
 end
-add_column_job(table, name, column) = create_job(Preprocess(add_column), table, name, column)
 
 
 
@@ -210,10 +195,10 @@ function _table_hcat_validated(args...)
 	common_names = [name for (name,count) in StatsBase.countmap(names) if count>1]
 	isempty(common_names) || throw(ArgumentError("Table column names must be different, found these common names: $common_names"))
 
-	result = create_table_job(Iterators.flatten(getproperty.(args,:args))...)
+	result = SCP.create_table(Iterators.flatten(getproperty.(args,:args))...)
 
 	# Check that the number of rows in all tables match
-	n = table_nrow_job.(args)
+	n = SCP.table_nrow.(args)
 	cond = allequal_job(n)
 	ifelse_pr_job(cond, result, _table_hcat_nrow_error_job(n))
 end
@@ -231,7 +216,6 @@ function table_hcat(::Preprocessing{E}, args...) where E
 end
 
 # TODO: Refactor to take a vector instead? Better for the compiler if there are many arguments.
-table_hcat_job(a, args...) = create_job(Preprocess(table_hcat), a, args...)
 
 
 
@@ -258,7 +242,7 @@ function table_getindex(::Preprocessing{E}, table, ind) where E
 		table # Projections have been handled, so indexing by `:` is OK
 	elseif is_create_table(table) # Move the operation to the columns if we can
 		cols = (k=>getindex_job(v, ind) for (k,v) in table.args)
-		create_table_job(cols...)
+		SCP.create_table(cols...)
 	elseif E # early is before projection, so we need to handle the projection
 		table_getindex_pr_job(table, ind)
 	else
@@ -268,7 +252,7 @@ function table_getindex(::Preprocessing{E}, table, ind) where E
 
 	# if is_create_table(table) # Move the operation to the columns if we can
 	# 	cols = (k=>getindex_job(v, ind) for (k,v) in table.args)
-	# 	create_table_job(cols...)
+	# 	SCP.create_table(cols...)
 	# elseif E # early is before projection, so we need to handle the projection
 	# 	table_getindex_pr_job(table, ind)
 	# elseif ind == Colon() # Projections have been handled, so indexing by `:` will not be transformed to something else
@@ -295,7 +279,7 @@ function _table_leftjoin(a, b)
 
 	ind_job = indexin_job(ids_a, ids_b; not_found=:nothing)
 	joined_cols = [k=>getindex_or_missing_job(v,ind_job) for (k,v) in b.args[2:end]]
-	create_table_job(a.args..., joined_cols...)
+	SCP.create_table(a.args..., joined_cols...)
 end
 
 function table_leftjoin_fallback(a::DataFrame, b::DataFrame)
@@ -317,7 +301,6 @@ function table_leftjoin(::Preprocessing{E}, a, b) where E
 	end
 end
 
-table_leftjoin_job(a, b) = create_job(Preprocess(table_leftjoin), a, b)
 
 
 
@@ -342,7 +325,7 @@ repeat_columns_fallback(table::DataFrame; kwargs...) = mapcols(v->repeat(v; kwar
 function repeat_columns(::Preprocessing{E}, table; kwargs...) where E
 	if is_create_table(table)
 		cols = (k=>repeat_job(v; kwargs...) for (k,v) in table.args)
-		create_table_job(cols...)
+		SCP.create_table(cols...)
 	elseif E
 		create_job(Preprocess{false}(repeat_columns), table; kwargs...)
 	else
@@ -365,7 +348,7 @@ function _intersect_ids(a, b)
 	a_name != b_name && throw(ArgumentError("ID column names \"$a_name\" and \"$b_name\" do not match."))
 
 	values = intersect_job(a_values, b_values)
-	create_table_job(a_name=>values)
+	SCP.create_table(a_name=>values)
 end
 
 function intersect_ids_fallback(a, b)
@@ -399,11 +382,10 @@ function transform_annotation(::Preprocessing{E}, f, table; kwargs...) where E
 	if is_create_table(table)
 		_check_ncol(table; require_n_cols=2)
 		name = @something get(kwargs, :new_name, nothing) table.args[2].first
-		create_table_job(table.args[1], name => apply_broadcasted_job(f, table.args[2].second))
+		SCP.create_table(table.args[1], name => apply_broadcasted_job(f, table.args[2].second))
 	elseif E
 		create_job(Preprocess{false}(transform_annotation), f, table; kwargs...)
 	else
 		create_job(transform_annotation_fallback, f, table; kwargs..., __version=v"0.1.0")
 	end
 end
-transform_annotation_job(f, table; kwargs...) = create_job(Preprocess(transform_annotation), f, table; kwargs...)

--- a/src/Impl/tables.jl
+++ b/src/Impl/tables.jl
@@ -111,10 +111,8 @@ id_column(::Preprocessing, table) = get_columns_job(table, 1)
 id_column_job(table) = create_job(Preprocess(id_column), table)
 
 value_column(::Preprocessing, table) = get_columns_job(table, 2; require_n_cols=2)
-value_column_job(table) = create_job(Preprocess(value_column), table)
 
 annotation(::Preprocessing, table, colname) = get_columns_job(table, fetched(get_id_colname_job(table)), colname) # If we add support for mixed column indexing, this could be (1, colname)
-annotation_job(table, colname) = create_job(Preprocess(annotation), table, colname)
 
 
 
@@ -146,7 +144,6 @@ column_data_job(table, col; kwargs...) = create_job(Preprocess(column_data), tab
 
 
 id_column_data(::Preprocessing, table) = column_data_job(table, 1)
-id_column_data_job(table) = create_job(Preprocess(id_column_data), table)
 
 value_column_data(::Preprocessing, table) = column_data_job(table, 2; require_n_cols=2)
 value_column_data_job(table) = create_job(Preprocess(value_column_data), table)
@@ -170,7 +167,6 @@ function table_ncol(::Preprocessing{E}, table) where E
 		create_job(table_ncol_fallback, table; __version=v"0.1.0")
 	end
 end
-table_ncol_job(table) = create_job(Preprocess(table_ncol), table)
 
 
 

--- a/src/Impl/transform.jl
+++ b/src/Impl/transform.jl
@@ -6,11 +6,11 @@ end
 
 
 function logtransform(f::Union{Mat,Var}, T::DataType, data; scale_factor)
-	matrix_job = get_matrix_job(data)
+	matrix_job = SCP.get_matrix(data)
 	create_job(Preprocess{false}(logtransform_matrix), T, matrix_job; scale_factor)
 end
-logtransform(::Var, ::DataType, data; kwargs...) = get_var_job(data)
-logtransform(::Obs, ::DataType, data; kwargs...) = get_obs_job(data)
+logtransform(::Var, ::DataType, data; kwargs...) = SCP.get_var(data)
+logtransform(::Obs, ::DataType, data; kwargs...) = SCP.get_obs(data)
 
 
 
@@ -75,7 +75,7 @@ function scparams(action::Action, matrix, var, var_ind; log_cell_counts)
 		return params
 	else#if actions is Projection
 		# We need to remap IDs
-		var_ids = id_column_job(var)
+		var_ids = SCP.id_column(var)
 		var_ids2 = action(var_ids)
 
 		param_ids = table_getindex_job(var_ids, var_ind) # The IDs represented in the params table
@@ -144,15 +144,15 @@ sctransform_matrix_job(T, matrix, params, log_cell_counts; var_ind, kwargs...) =
 
 
 function sctransform(f::Union{Mat,Var}, ::Type{T}, counts; var_filter=:, min_cells=5, annotate=false, kwargs...) where T
-	matrix_job = get_matrix_job(counts)
-	var_job = get_var_job(counts)
+	matrix_job = SCP.get_matrix(counts)
+	var_job = SCP.get_var(counts)
 
 	var_ind_logcellcounts = prefetched(create_find_matching_ind_job(var_filter, var_job; project_ids=:intersect))
 	log_cell_counts = logcellcounts_job(matrix_job, var_ind_logcellcounts)
 
 	# min_cells
 	nnz_cells = cached(counts_sum_impl_job(!iszero, matrix_job, :; dims=2)) # returns vector
-	var_nnz_cells = add_column_job(id_column_job(var_job), "nnzCells", nnz_cells)
+	var_nnz_cells = SCP.add_column(SCP.id_column(var_job), "nnzCells", nnz_cells)
 	var_ind_min_cells = create_find_matching_ind_job("nnzCells"=>>=(min_cells), var_nnz_cells; project_ids=:yes)
 
 	var_ind = prefetched(intersect_ind_job(var_ind_logcellcounts, var_ind_min_cells))
@@ -161,15 +161,15 @@ function sctransform(f::Union{Mat,Var}, ::Type{T}, counts; var_filter=:, min_cel
 	if f isa Var
 		var_out = table_getindex_job(var_job, var_ind)
 		if annotate
-			var_out = table_hcat_job(var_out, params_job)
+			var_out = SCP.table_hcat(var_out, params_job)
 		end
 		return var_out
 	else # if f isa Mat
-		nobs = fetched(nobs_job(counts)) # fetch since we need the value now and the value should **not** be affected by projecion
+		nobs = fetched(SCP.nobs(counts)) # fetch since we need the value now and the value should **not** be affected by projecion
 		return sctransform_matrix_job(T, matrix_job, params_job, log_cell_counts; var_ind, nobs, kwargs...)
 	end
 end
-sctransform(::Obs, ::DataType, counts; kwargs...) = get_obs_job(counts)
+sctransform(::Obs, ::DataType, counts; kwargs...) = SCP.get_obs(counts)
 
 
 

--- a/src/Impl/transform_coords.jl
+++ b/src/Impl/transform_coords.jl
@@ -20,11 +20,6 @@ end
 transform_coords(::Obs, data, transform; kwargs...) = get_obs_job(data)
 
 
-transform_coords_job(data, transform; kwargs...) =
-	create_job(DataMatrixFunction(transform_coords), data, transform; kwargs...)
-
-
-
 _default_transform_axis_order(::Val{2}) = [2,1] # y is up
 _default_transform_axis_order(::Val{3}) = [3,1,2] # z is up
 _default_transform_axis_order(::Val{N}) where N = nothing # default
@@ -61,6 +56,3 @@ function find_optimal_coord_transform(::Action, data, args...; kwargs...)
 	ind_specs = (create_find_matching_ind_job(arg, get_obs_job(data); project_ids=:no) for arg in args)
 	create_job(find_optimal_coord_transform_impl, get_matrix_job(data), ind_specs...; kwargs..., __version=v"0.1.0")
 end
-
-find_optimal_coord_transform_job(args...; kwargs...) =
-	create_job(Projectable(find_optimal_coord_transform), args...; kwargs...)

--- a/src/Impl/transform_coords.jl
+++ b/src/Impl/transform_coords.jl
@@ -8,16 +8,16 @@ function transform_coords_impl(X::TM, transform::TT) where {TM,TT}
 end
 
 transform_coords(::Mat, data, transform; kwargs...) =
-	create_job(transform_coords_impl, get_matrix_job(data), transform; __version=v"0.0.1")
+	create_job(transform_coords_impl, SCP.get_matrix(data), transform; __version=v"0.0.1")
 function transform_coords(::Var, data, transform; keep_var=false)
 	if keep_var
-		get_var_job(data)
+		SCP.get_var(data)
 	else
 		prefixed_ids_job("dim_id", "dim", size(transform,1))
 	end
 end
 
-transform_coords(::Obs, data, transform; kwargs...) = get_obs_job(data)
+transform_coords(::Obs, data, transform; kwargs...) = SCP.get_obs(data)
 
 
 _default_transform_axis_order(::Val{2}) = [2,1] # y is up
@@ -53,6 +53,6 @@ find_optimal_coord_transform_impl(X::ROMat, args...; kwargs...) = find_optimal_c
 
 function find_optimal_coord_transform(::Action, data, args...; kwargs...)
 	# NB: Do not apply action at all, the layout is based on the unprojected data set
-	ind_specs = (create_find_matching_ind_job(arg, get_obs_job(data); project_ids=:no) for arg in args)
-	create_job(find_optimal_coord_transform_impl, get_matrix_job(data), ind_specs...; kwargs..., __version=v"0.1.0")
+	ind_specs = (create_find_matching_ind_job(arg, SCP.get_obs(data); project_ids=:no) for arg in args)
+	create_job(find_optimal_coord_transform_impl, SCP.get_matrix(data), ind_specs...; kwargs..., __version=v"0.1.0")
 end

--- a/src/SingleCellProjections.jl
+++ b/src/SingleCellProjections.jl
@@ -192,7 +192,7 @@ function tsne end
 
 include("Impl/Impl.jl")
 
-using .Impl: DataMatrixFunction
+using .Impl: DataMatrixFunction, Projectable
 
 
 include("projectables.jl")

--- a/src/annotation_transfer.jl
+++ b/src/annotation_transfer.jl
@@ -10,4 +10,4 @@ Returns a table with the transferred labels and confidence scores.
 (TODO: Add example - maybe I need to construct one? It should be about celltype transfer.)
 """
 transfer_annotation(base, new, covariate; k, kwargs...) =
-	Impl.transfer_annotation_job(base, new, covariate; k, kwargs...)
+	create_job(Preprocess(Impl.transfer_annotation), base, new, covariate; k, kwargs...)

--- a/src/datamatrixfunctions.jl
+++ b/src/datamatrixfunctions.jl
@@ -5,7 +5,7 @@ Extract the matrix component from a `DataMatrix` `Job`.
 
 See also [`get_var`](@ref), [`get_obs`](@ref).
 """
-get_matrix(x) = Impl.get_matrix_job(x)
+get_matrix(x) = create_job(Preprocess(Impl.get_matrix), x)
 
 """
     SCP.get_var(data) -> Job
@@ -14,7 +14,7 @@ Extract the variable annotation table from a `DataMatrix` `Job`.
 
 See also [`get_matrix`](@ref), [`get_obs`](@ref).
 """
-get_var(x) = Impl.get_var_job(x)
+get_var(x) = create_job(Preprocess(Impl.get_var), x)
 
 """
     SCP.get_obs(data) -> Job
@@ -23,4 +23,4 @@ Extract the observation annotation table from a `DataMatrix` `Job`.
 
 See also [`get_matrix`](@ref), [`get_var`](@ref).
 """
-get_obs(x) = Impl.get_obs_job(x)
+get_obs(x) = create_job(Preprocess(Impl.get_obs), x)

--- a/src/design.jl
+++ b/src/design.jl
@@ -43,6 +43,6 @@ Construct a design matrix from observation covariates. Covariates can be column 
 
 See also [`normalize_matrix`](@ref), [`negative_regression_matrix`](@ref).
 """
-function designmatrix(data, args...; kwargs...)
-	Impl.designmatrix_job(data, args...; kwargs...)
+function designmatrix(data, args...; center=true, kwargs...)
+	create_job(Preprocess(Impl.designmatrix), data, args...; center, kwargs...)
 end

--- a/src/internal.jl
+++ b/src/internal.jl
@@ -5,7 +5,7 @@ Return a `Job` for the number of variables (rows) in `data`.
 
 See also [`nobs`](@ref).
 """
-nvar(data) = Impl.nvar_job(data)
+nvar(data) = table_nrow(get_var(data))
 
 """
     SCP.nobs(data) -> Job
@@ -14,4 +14,4 @@ Return a `Job` for the number of observations (columns) in `data`.
 
 See also [`nvar`](@ref).
 """
-nobs(data) = Impl.nobs_job(data)
+nobs(data) = table_nrow(get_obs(data))

--- a/src/load.jl
+++ b/src/load.jl
@@ -1,14 +1,5 @@
 _is_h5(filename) = lowercase(splitext(filename)[2]) == ".h5"
 
-# `nothing` -> guess a sibling file for each input; otherwise normalize to a vector matching `filenames`.
-function _component_filenames(given, filenames, guess)
-	given === nothing && return guess.(filenames)
-	given isa AbstractArray || (given = [given])
-	length(given) == length(filenames) ||
-		throw(ArgumentError("Expected $(length(filenames)) filename(s), got $(length(given))."))
-	given
-end
-
 """
     SCP.load_counts(filenames; sample_names, feature_filenames=nothing, barcode_filenames=nothing, prefilter="feature_type"=>isequal("Gene Expression"), extra_id_cols="feature_type", kwargs...) -> Job
 
@@ -45,28 +36,37 @@ julia> SCP.load_counts("matrix.mtx.gz"; sample_names="SampleA")
 See also [`load_csv`](@ref).
 """
 function load_counts(filenames;
-                          sample_names,
-                          feature_filenames = nothing,
-                          barcode_filenames = nothing,
-                          prefilter = "feature_type"=>isequal("Gene Expression"),
-                          extra_id_cols = "feature_type", # TODO: Remove this default value?
-                          kwargs...)
+                     sample_names,
+                     feature_filenames = nothing,
+                     barcode_filenames = nothing,
+                     prefilter = "feature_type"=>isequal("Gene Expression"),
+                     extra_id_cols = "feature_type", # TODO: Remove this default value?
+                     kwargs...)
 	filenames isa AbstractArray || (filenames = [filenames])
 	sample_names isa AbstractArray || (sample_names = [sample_names])
 
 	matrix_specs = checksummedfilepath_job.(filenames)
 
-	# Legacy path: pure .h5 with no explicit component files - keep the spec (and hashes) unchanged.
-	if feature_filenames === nothing && barcode_filenames === nothing && all(_is_h5, filenames)
-		return create_job(DataMatrixFunction(Impl.load_counts), matrix_specs; sample_names, prefilter, extra_id_cols, kwargs...)
+	extra_kwargs = (;)
+	if !all(_is_h5, filenames) || feature_filenames !== nothing || barcode_filenames !== nothing
+		# We need to specify feature and barcode filenames separately.
+
+		feature_filenames = @something feature_filenames SingleCell10x.guessfeaturefilename.(filenames)
+		feature_filenames isa AbstractArray || (feature_filenames = [feature_filenames])
+		feature_specs = checksummedfilepath_job.(feature_filenames)
+
+		barcode_filenames = @something barcode_filenames SingleCell10x.guessbarcodefilename.(filenames)
+		barcode_filenames isa AbstractArray || (barcode_filenames = [barcode_filenames])
+		barcode_specs = checksummedfilepath_job.(barcode_filenames)
+
+		nm = length(matrix_specs)
+		nf = length(feature_specs)
+		nb = length(barcode_specs)
+
+		nm != nf && throw(ArgumentError("The number of matrix filenames ($nm) and feature filenames ($nf) are not equal."))
+		nm != nb && throw(ArgumentError("The number of matrix filenames ($nm) and barcode filenames ($nb) are not equal."))
+
+		extra_kwargs = (; feature_specs, barcode_specs)
 	end
-
-	# General path: .mtx and/or explicit feature/barcode files. Guess the sibling files when not given
-	# (for a .h5 input the guess returns the .h5 path itself).
-	feature_files = _component_filenames(feature_filenames, filenames, SingleCell10x.guessfeaturefilename)
-	barcode_files = _component_filenames(barcode_filenames, filenames, SingleCell10x.guessbarcodefilename)
-	feature_specs = checksummedfilepath_job.(feature_files)
-	barcode_specs = checksummedfilepath_job.(barcode_files)
-
-	create_job(DataMatrixFunction(Impl.load_counts), matrix_specs, feature_specs, barcode_specs; sample_names, prefilter, extra_id_cols, kwargs...)
+	create_job(DataMatrixFunction(Impl.load_counts), matrix_specs; sample_names, prefilter, extra_id_cols, extra_kwargs..., kwargs...)
 end

--- a/src/load.jl
+++ b/src/load.jl
@@ -1,10 +1,26 @@
-"""
-    SCP.load_counts(filenames; sample_names, prefilter="feature_type"=>isequal("Gene Expression"), extra_id_cols="feature_type", kwargs...) -> Job
+_is_h5(filename) = lowercase(splitext(filename)[2]) == ".h5"
 
-Load raw count matrices from one or more 10x HDF5 (.h5) files. Returns a `Job` whose
-result is a `DataMatrix` with genes as variables and cells as observations.
+# `nothing` -> guess a sibling file for each input; otherwise normalize to a vector matching `filenames`.
+function _component_filenames(given, filenames, guess)
+	given === nothing && return guess.(filenames)
+	given isa AbstractArray || (given = [given])
+	length(given) == length(filenames) ||
+		throw(ArgumentError("Expected $(length(filenames)) filename(s), got $(length(given))."))
+	given
+end
+
+"""
+    SCP.load_counts(filenames; sample_names, feature_filenames=nothing, barcode_filenames=nothing, prefilter="feature_type"=>isequal("Gene Expression"), extra_id_cols="feature_type", kwargs...) -> Job
+
+Load raw count matrices from one or more 10x files. Returns a `Job` whose result is a
+`DataMatrix` with genes as variables and cells as observations.
+
+Each file can be a 10x HDF5 (`.h5`) file, or a CellRanger Matrix Market matrix
+(`.mtx[.gz]`). For a `.mtx` file, the matching feature and barcode files are found in the same
+folder (following the CellRanger naming convention), or can be given explicitly.
 
 * `sample_names` is required and assigns a name to each sample.
+* `feature_filenames` / `barcode_filenames` — explicit feature/barcode files (a single filename or a vector matching `filenames`). When `nothing` (default), they are guessed from each `.mtx` filename; for a `.h5` file the file itself is used.
 * `prefilter` selects which features to keep (defaults to Gene Expression only).
 * `extra_id_cols` specifies additional columns used (together with the first column) to uniquely identify variables when merging samples. Variables with matching ID columns are combined.
 
@@ -20,21 +36,37 @@ Load multiple samples:
 julia> SCP.load_counts(["SampleA.h5", "SampleB.h5"]; sample_names=["SampleA","SampleB"])
 ```
 
+Load from a Matrix Market file (features/barcodes found in the same folder):
+```julia
+julia> SCP.load_counts("matrix.mtx.gz"; sample_names="SampleA")
+```
+
 
 See also [`load_csv`](@ref).
 """
 function load_counts(filenames;
                           sample_names,
+                          feature_filenames = nothing,
+                          barcode_filenames = nothing,
                           prefilter = "feature_type"=>isequal("Gene Expression"),
                           extra_id_cols = "feature_type", # TODO: Remove this default value?
                           kwargs...)
 	filenames isa AbstractArray || (filenames = [filenames])
 	sample_names isa AbstractArray || (sample_names = [sample_names])
 
-	# TODO: Support .mtx.gz, with the added complication that we need to find matching
-	#       feature/barcode files already here so that they can be checksummed too.
-	@assert all(x->lowercase(splitext(x)[2])==".h5", filenames) "Only 10x .h5 files are currently supported"
+	matrix_specs = checksummedfilepath_job.(filenames)
 
-	filename_specs = checksummedfilepath_job.(filenames)
-	create_job(DataMatrixFunction(Impl.load_counts), filename_specs; sample_names, prefilter, extra_id_cols, kwargs...)
+	# Legacy path: pure .h5 with no explicit component files - keep the spec (and hashes) unchanged.
+	if feature_filenames === nothing && barcode_filenames === nothing && all(_is_h5, filenames)
+		return create_job(DataMatrixFunction(Impl.load_counts), matrix_specs; sample_names, prefilter, extra_id_cols, kwargs...)
+	end
+
+	# General path: .mtx and/or explicit feature/barcode files. Guess the sibling files when not given
+	# (for a .h5 input the guess returns the .h5 path itself).
+	feature_files = _component_filenames(feature_filenames, filenames, SingleCell10x.guessfeaturefilename)
+	barcode_files = _component_filenames(barcode_filenames, filenames, SingleCell10x.guessbarcodefilename)
+	feature_specs = checksummedfilepath_job.(feature_files)
+	barcode_specs = checksummedfilepath_job.(barcode_files)
+
+	create_job(DataMatrixFunction(Impl.load_counts), matrix_specs, feature_specs, barcode_specs; sample_names, prefilter, extra_id_cols, kwargs...)
 end

--- a/src/local_outlier_factor.jl
+++ b/src/local_outlier_factor.jl
@@ -7,6 +7,6 @@ neighbors. Returns a table with IDs and LOF scores in a column named `col`.
 
 When projecting, only neighbors in the base dataset are considered.
 """
-function local_outlier_factor(data, full; kwargs...)
-	Impl.local_outlier_factor_job(data, full; kwargs...)
+function local_outlier_factor(data, full; k=10, col="LOF")
+	create_job(Preprocess(Impl.local_outlier_factor_pre), data, full; k, col)
 end

--- a/src/pseudobulk.jl
+++ b/src/pseudobulk.jl
@@ -9,7 +9,7 @@ specified covariates. Returns a `DataMatrix` where each column is a pseudobulk s
 See also [`population_matrix`](@ref).
 """
 function pseudobulk(data, obs_covariate1, obs_covariates...; kwargs...)
-	Impl.pseudobulk_job(data, obs_covariate1, obs_covariates...; kwargs...)
+	create_job(Preprocess(Impl.pseudobulk), data, obs_covariate1, obs_covariates...; kwargs...)
 end
 
 
@@ -26,5 +26,5 @@ covariates define the columns (samples/groups) and `new_var_covariates` define t
 See also [`pseudobulk`](@ref).
 """
 function population_matrix(obs, obs_covariate1, obs_covariates...; new_var_covariates, kwargs...)
-	Impl.population_matrix_job(obs, obs_covariate1, obs_covariates...; new_var_covariates, kwargs...)
+	create_job(Preprocess(Impl.population_matrix), obs, obs_covariate1, obs_covariates...; new_var_covariates, kwargs...)
 end

--- a/src/signatures.jl
+++ b/src/signatures.jl
@@ -10,5 +10,5 @@ with IDs and the signature scores in a column named `out_col_name`.
 See also [`pca`](@ref), [`loadings`](@ref).
 """
 function signature(data, var_filter, out_col_name; kwargs...)
-	Impl.signature_job(data, var_filter, out_col_name; kwargs...)
+	create_job(Preprocess(Impl.signature_pre), data, var_filter, out_col_name; kwargs...)
 end

--- a/src/statistical_tests.jl
+++ b/src/statistical_tests.jl
@@ -13,7 +13,7 @@ a single categorical covariate, this is equivalent to a one-way ANOVA.
 See also [`ttest`](@ref), [`normalize_matrix`](@ref).
 """
 function ftest(data, h1; kwargs...)
-	Impl.ftest_job(data, h1; kwargs...)
+	create_job(Preprocess(Impl.ftest), data, h1; kwargs...)
 end
 
 
@@ -29,5 +29,5 @@ two-group covariate.
 See also [`ftest`](@ref), [`normalize_matrix`](@ref), [`twogroup_covariate`](@ref).
 """
 function ttest(data, h1; kwargs...)
-	Impl.ttest_job(data, h1; kwargs...)
+	create_job(Preprocess(Impl.ttest), data, h1; kwargs...)
 end

--- a/src/sum_squared.jl
+++ b/src/sum_squared.jl
@@ -9,7 +9,7 @@ Compute the variance of each variable in `data`, returning a table with IDs and 
 See also [`std`](@ref), [`relative_std`](@ref), [`normalize_matrix`](@ref).
 """
 function variance(X; kwargs...)
-	Impl.variance_job(X; kwargs...)
+	create_job(Projectable(Impl.compute_variance), X; kwargs...)
 end
 
 
@@ -24,7 +24,7 @@ Compute the standard deviation of each variable in `data`, returning a table wit
 See also [`variance`](@ref), [`relative_std`](@ref), [`normalize_matrix`](@ref).
 """
 function std(X; kwargs...)
-	Impl.std_job(X; kwargs...)
+	create_job(Preprocess(Impl.compute_std), X; kwargs...)
 end
 
 
@@ -44,5 +44,5 @@ only variables whose std is at least a fraction `f` of the highest-std variable.
 See also [`variance`](@ref), [`std`](@ref), [`normalize_matrix`](@ref).
 """
 function relative_std(X; kwargs...)
-	Impl.relative_std_job(X; kwargs...)
+	create_job(Preprocess(Impl.compute_relative_std), X; kwargs...)
 end

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -58,7 +58,7 @@ Extract the second (value) column of `table` as a single-column table.
 
 See also [`id_column`](@ref), [`value_column_data`](@ref).
 """
-value_column(table) = Impl.value_column_job(table)
+value_column(table) = create_job(Preprocess(Impl.value_column), table)
 
 """
     SCP.annotation(table, colname) -> Job
@@ -66,7 +66,7 @@ value_column(table) = Impl.value_column_job(table)
 Extract the ID column and the column named `colname` from `table`, returning a two-column
 table. Useful for passing annotations to filtering or covariate specification.
 """
-annotation(table, colname) = Impl.annotation_job(table, colname)
+annotation(table, colname) = create_job(Preprocess(Impl.annotation), table, colname)
 
 """
     SCP.column_data(table, col; kwargs...) -> Job
@@ -84,7 +84,7 @@ Return the vector of IDs (first column) from `table`.
 
 See also [`column_data`](@ref), [`value_column_data`](@ref).
 """
-id_column_data(table) = Impl.id_column_data_job(table)
+id_column_data(table) = create_job(Preprocess(Impl.id_column_data), table)
 
 """
     SCP.value_column_data(table) -> Job
@@ -112,7 +112,7 @@ Return the number of columns in `table`.
 
 See also [`table_nrow`](@ref).
 """
-table_ncol(table) = Impl.table_ncol_job(table)
+table_ncol(table) = create_job(Preprocess(Impl.table_ncol), table)
 
 """
     SCP.add_column(table, name, column) -> Job

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -3,7 +3,7 @@
 
 Create a new table `Job` from column name/value pairs.
 """
-create_table(args...) = Impl.create_table_job(args...)
+create_table(args...) = create_job(Impl.create_table, args...; __version=v"0.1.0")
 
 """
     SCP.get_colnames(table; kwargs...) -> Job
@@ -12,7 +12,7 @@ Return the column names of `table`.
 
 See also [`get_id_colname`](@ref), [`get_value_colname`](@ref).
 """
-get_colnames(table, args...; kwargs...) = Impl.get_colnames_job(table, args...; kwargs...)
+get_colnames(table, args...; kwargs...) = create_job(Preprocess(Impl.get_colnames), table, args...; kwargs...)
 
 """
     SCP.get_id_colname(table) -> Job
@@ -21,7 +21,7 @@ Return the name of the first (ID) column of `table`.
 
 See also [`get_colnames`](@ref), [`get_value_colname`](@ref).
 """
-get_id_colname(table) = Impl.get_id_colname_job(table)
+get_id_colname(table) = create_job(Preprocess(Impl.get_colnames), table, 1)
 
 """
     SCP.get_value_colname(table) -> Job
@@ -31,7 +31,7 @@ exactly two columns.
 
 See also [`get_colnames`](@ref), [`get_id_colname`](@ref).
 """
-get_value_colname(table) = Impl.get_value_colname_job(table)
+get_value_colname(table) = create_job(Preprocess(Impl.get_colnames), table, 2; require_n_cols=2)
 
 """
     SCP.get_columns(table, colnames...) -> Job
@@ -40,7 +40,7 @@ Select specific columns from `table` by name or index.
 
 See also [`id_column`](@ref), [`value_column`](@ref).
 """
-get_columns(table, colname1, colnames...; kwargs...) = Impl.get_columns_job(table, colname1, colnames...; kwargs...)
+get_columns(table, colname1, colnames...; kwargs...) = create_job(Preprocess(Impl.get_columns), table, colname1, colnames...; kwargs...)
 
 """
     SCP.id_column(table) -> Job
@@ -49,7 +49,7 @@ Extract the first (ID) column of `table` as a single-column table.
 
 See also [`value_column`](@ref), [`id_column_data`](@ref).
 """
-id_column(table) = Impl.id_column_job(table)
+id_column(table) = create_job(Preprocess(Impl.id_column), table)
 
 """
     SCP.value_column(table) -> Job
@@ -75,7 +75,7 @@ Return the values of column `col` from `table` as a vector.
 
 See also [`id_column_data`](@ref), [`value_column_data`](@ref).
 """
-column_data(table, col; kwargs...) = Impl.column_data_job(table, col; kwargs...)
+column_data(table, col; kwargs...) = create_job(Preprocess(Impl.column_data), table, col; kwargs...)
 
 """
     SCP.id_column_data(table) -> Job
@@ -94,7 +94,7 @@ exactly two columns.
 
 See also [`column_data`](@ref), [`id_column_data`](@ref).
 """
-value_column_data(table) = Impl.value_column_data_job(table)
+value_column_data(table) = create_job(Preprocess(Impl.value_column_data), table)
 
 """
     SCP.table_nrow(table) -> Job
@@ -103,7 +103,7 @@ Return the number of rows in `table`.
 
 See also [`table_ncol`](@ref).
 """
-table_nrow(table) = Impl.table_nrow_job(table)
+table_nrow(table) = create_job(Preprocess(Impl.table_nrow), table)
 
 """
     SCP.table_ncol(table) -> Job
@@ -122,7 +122,7 @@ The length of `column` must match the number of rows in `table`.
 
 See also [`table_hcat`](@ref), [`add_var_column`](@ref), [`add_obs_column`](@ref).
 """
-add_column(table, name, column) = Impl.add_column_job(table, name, column)
+add_column(table, name, column) = create_job(Preprocess(Impl.add_column), table, name, column)
 
 """
     SCP.table_hcat(a, tables...) -> Job
@@ -132,7 +132,7 @@ matching row order.
 
 See also [`table_leftjoin`](@ref), [`add_column`](@ref).
 """
-table_hcat(a, args...) = Impl.table_hcat_job(a, args...)
+table_hcat(a, args...) = create_job(Preprocess(Impl.table_hcat), a, args...)
 
 """
     SCP.table_leftjoin(a, b) -> Job
@@ -141,7 +141,7 @@ Left-join table `b` onto table `a` by their ID columns.
 
 See also [`table_hcat`](@ref), [`annotate_var`](@ref), [`annotate_obs`](@ref).
 """
-table_leftjoin(a, b) = Impl.table_leftjoin_job(a, b)
+table_leftjoin(a, b) = create_job(Preprocess(Impl.table_leftjoin), a, b)
 
 """
     SCP.transform_annotation(f, table; kwargs...) -> Job
@@ -152,4 +152,4 @@ Use `new_name` to rename the value column.
 
 (TODO: Example.)
 """
-transform_annotation(f, table; kwargs...) = Impl.transform_annotation_job(f, table; kwargs...)
+transform_annotation(f, table; kwargs...) = create_job(Preprocess(Impl.transform_annotation), f, table; kwargs...)

--- a/src/transform_coords.jl
+++ b/src/transform_coords.jl
@@ -83,7 +83,7 @@ Apply a coordinate transformation matrix `transform` to the matrix of `data`.
 See also [`find_optimal_coord_transform`](@ref), [`force_layout`](@ref).
 """
 transform_coords(data, transform; kwargs...) =
-	Impl.transform_coords_job(data, transform; kwargs...)
+	create_job(DataMatrixFunction(Impl.transform_coords), data, transform; kwargs...)
 
 
 # Find a better name?
@@ -119,5 +119,5 @@ julia> fl_rotated = SCP.transform_coords(fl_2d, transform; keep_var=true)
 See also [`transform_coords`](@ref), [`force_layout`](@ref).
 """
 function find_optimal_coord_transform(args...; kwargs...)
-	Impl.find_optimal_coord_transform_job(args...)
+	create_job(Projectable(Impl.find_optimal_coord_transform), args...; kwargs...)
 end

--- a/test/load.jl
+++ b/test/load.jl
@@ -7,7 +7,6 @@ function run_load_tests()
 	@testset "load_counts" begin
 		P,N = (50,587)
 
-		# TODO: Test .mtx file (implement with specs first!)
 		counts_job = SCP.load_counts(h5_path; sample_names="a")
 
 		counts_sub_job = SCP.load_counts(h5_subset_path; sample_names="p")
@@ -51,6 +50,67 @@ function run_load_tests()
 			obs_sub_job = SCP.get_obs(counts_sub_job)
 			p_obs_job = SCP.project(obs_job, obs_job=>obs_sub_job)
 			@test isequal(forward!(p_obs_job), forward!(obs_sub_job))
+		end
+
+		@testset "Matrix Market (.mtx)" begin
+			mtx_dir   = joinpath(pbmc_path, "filtered_feature_bc_matrix")
+			feat_path = joinpath(mtx_dir, "features.tsv.gz")
+			bc_path   = joinpath(mtx_dir, "barcodes.tsv.gz")
+
+			mtx_job = SCP.load_counts(mtx_path; sample_names="a")
+			let mtx = fetch!(mtx_job)
+				@test size(mtx) == (P,N)
+				@test unblockify(mtx.matrix) == expected_mat
+				@test unblockify(mtx.matrix) isa SparseMatrixCSC{Int64,Int32}
+
+				# obs is identical to the .h5 load
+				@test names(mtx.obs) == ["cell_id", "sample_name", "barcode"]
+				@test mtx.obs.cell_id == string.("a_", expected_barcodes)
+				@test mtx.obs.sample_name == fill("a",N)
+				@test mtx.obs.barcode == expected_barcodes
+
+				# var: features.tsv has no `genome` column, but the shared columns match the .h5 load
+				@test names(mtx.var) == ["id", "name", "feature_type"]
+				@test mtx.var.id == expected_feature_ids
+				@test mtx.var.name == expected_feature_names
+				@test mtx.var.feature_type == expected_feature_types
+			end
+
+			# explicit feature/barcode filenames give the same result as guessing them
+			let mtx = fetch!(mtx_job),
+			    mtx_expl = fetch!(SCP.load_counts(mtx_path; sample_names="a", feature_filenames=feat_path, barcode_filenames=bc_path))
+				@test unblockify(mtx_expl.matrix) == unblockify(mtx.matrix)
+				@test isequal(mtx_expl.var, mtx.var)
+				@test isequal(mtx_expl.obs, mtx.obs)
+			end
+
+			# a mismatched number of explicit filenames is an error
+			@test_throws ArgumentError SCP.load_counts([mtx_path]; sample_names="a", feature_filenames=[feat_path, feat_path])
+		end
+
+		@testset "Mixed .h5 and .mtx" begin
+			# load one .h5 sample and one .mtx sample in the same call (same underlying data)
+			mixed = fetch!(SCP.load_counts([h5_path, mtx_path]; sample_names=["a","b"]))
+			@test size(mixed) == (P, 2N)
+
+			# obs: both samples merged, in order
+			@test names(mixed.obs) == ["cell_id", "sample_name", "barcode"]
+			@test mixed.obs.sample_name == [fill("a",N); fill("b",N)]
+			@test mixed.obs.cell_id == [string.("a_",expected_barcodes); string.("b_",expected_barcodes)]
+
+			# var: `id`/`name`/`feature_type` agree across both samples and are kept. `genome` exists
+			# only in the .h5 features, so per gene the value is inconsistent across the two samples and
+			# `combine_var` marks it "ambiguous" (its sentinel for annotations that differ between samples).
+			@test names(mixed.var) == ["id", "name", "feature_type", "genome"]
+			@test mixed.var.id == expected_feature_ids
+			@test mixed.var.name == expected_feature_names
+			@test mixed.var.feature_type == expected_feature_types
+			@test all(==("ambiguous"), mixed.var.genome)
+
+			# each sample's block equals the expected matrix
+			M = unblockify(mixed.matrix)
+			@test M[:, mixed.obs.sample_name .== "a"] == expected_mat
+			@test M[:, mixed.obs.sample_name .== "b"] == expected_mat
 		end
 	end
 end

--- a/test/load.jl
+++ b/test/load.jl
@@ -53,10 +53,6 @@ function run_load_tests()
 		end
 
 		@testset "Matrix Market (.mtx)" begin
-			mtx_dir   = joinpath(pbmc_path, "filtered_feature_bc_matrix")
-			feat_path = joinpath(mtx_dir, "features.tsv.gz")
-			bc_path   = joinpath(mtx_dir, "barcodes.tsv.gz")
-
 			mtx_job = SCP.load_counts(mtx_path; sample_names="a")
 			let mtx = fetch!(mtx_job)
 				@test size(mtx) == (P,N)
@@ -76,16 +72,16 @@ function run_load_tests()
 				@test mtx.var.feature_type == expected_feature_types
 			end
 
-			# explicit feature/barcode filenames give the same result as guessing them
-			let mtx = fetch!(mtx_job),
-			    mtx_expl = fetch!(SCP.load_counts(mtx_path; sample_names="a", feature_filenames=feat_path, barcode_filenames=bc_path))
-				@test unblockify(mtx_expl.matrix) == unblockify(mtx.matrix)
-				@test isequal(mtx_expl.var, mtx.var)
-				@test isequal(mtx_expl.obs, mtx.obs)
-			end
+			feat_path = joinpath(dirname(mtx_path), "features.tsv.gz")
+			bc_path   = joinpath(dirname(mtx_path), "barcodes.tsv.gz")
+
+			# Specifying paths identical to the guessed paths should result in identical jobs (after forwarding)
+			mtx_job2 = SCP.load_counts(mtx_path; sample_names="a", feature_filenames=feat_path, barcode_filenames=bc_path)
+			@test forward!(mtx_job2) === forward!(mtx_job)
 
 			# a mismatched number of explicit filenames is an error
 			@test_throws ArgumentError SCP.load_counts([mtx_path]; sample_names="a", feature_filenames=[feat_path, feat_path])
+			@test_throws ArgumentError SCP.load_counts([mtx_path]; sample_names="a", barcode_filenames=[bc_path, bc_path])
 		end
 
 		@testset "Mixed .h5 and .mtx" begin

--- a/test/projectables.jl
+++ b/test/projectables.jl
@@ -1,7 +1,8 @@
 using Test
 using SingleCellProjections
 using SingleCellProjections: SCPCore
-using SingleCellProjections.Impl: Impl, Projectable, ProjectOnto, Action, DataMatrixFunction, Mat, Var, Obs, MatFunction, get_matrix_job, prefixed_ids_job
+using SingleCellProjections: get_matrix
+using SingleCellProjections.Impl: Impl, Projectable, ProjectOnto, Action, DataMatrixFunction, Mat, Var, Obs, MatFunction, prefixed_ids_job
 using ReproducibleJobs: Preprocess, prefetched, create_job, fetch!, forward!, forward_once!
 using StableRNGs
 using DataFrames
@@ -67,19 +68,19 @@ dm_rand(::Var, S, nrow, ncol; kwargs...) = prefixed_ids_job("var_id", "var_", nr
 dm_rand(::Obs, S, nrow, ncol; kwargs...) = prefixed_ids_job("obs_id", "obs_", ncol)
 TestJobs.dm_rand(args...; kwargs...) = create_job(DataMatrixFunction(dm_rand), args...; kwargs...)
 
-dm_add(::Mat, a, b) = my_add_job(get_matrix_job(a), get_matrix_job(b))
+dm_add(::Mat, a, b) = my_add_job(get_matrix(a), get_matrix(b))
 dm_add(f, a, b) = Impl.get_job(f, a) # Var/Obs
 TestJobs.dm_add(a, b) = create_job(DataMatrixFunction(dm_add), a, b)
 
-dm_sub(::Mat, a, b) = my_sub_job(get_matrix_job(a), get_matrix_job(b))
+dm_sub(::Mat, a, b) = my_sub_job(get_matrix(a), get_matrix(b))
 dm_sub(f, a, b) = Impl.get_job(f, a) # Var/Obs
 TestJobs.dm_sub(a, b) = create_job(DataMatrixFunction(dm_sub), a, b)
 
-dm_mul(::Mat, a, b) = my_mul_job(get_matrix_job(a), get_matrix_job(b))
+dm_mul(::Mat, a, b) = my_mul_job(get_matrix(a), get_matrix(b))
 dm_mul(f, a, b) = Impl.get_job(f, a) # Var/Obs
 TestJobs.dm_mul(a, b) = create_job(DataMatrixFunction(dm_mul), a, b)
 
-dm_div(::Mat, a, b) = my_div_job(get_matrix_job(a), get_matrix_job(b))
+dm_div(::Mat, a, b) = my_div_job(get_matrix(a), get_matrix(b))
 dm_div(f, a, b) = Impl.get_job(f, a) # Var/Obs
 TestJobs.dm_div(a, b) = create_job(DataMatrixFunction(dm_div), a, b)
 


### PR DESCRIPTION
# Support loading 10x `.mtx` files in `load_counts`

## Summary

`SCP.load_counts` previously accepted only 10x HDF5 (`.h5`) files (it asserted *"Only 10x .h5 files
are currently supported"*). It now also loads CellRanger Matrix Market matrices (`.mtx[.gz]`).

```julia
SCP.load_counts("matrix.mtx.gz"; sample_names="SampleA")
```

An `.h5` file bundles matrix + features + barcodes; a `.mtx` sample is **three** files
(`matrix.mtx[.gz]`, `features/genes.tsv[.gz]`, `barcodes.tsv[.gz]`). The public function resolves the
sibling feature/barcode files from the `.mtx` path, and the returned job carries a
**checksummed-filepath argument for each of the three**, so cache invalidation tracks every input.
Mixed `.h5`/`.mtx` in a single call works (each filename is resolved independently).

The feature/barcode files can also be given explicitly:

```julia
SCP.load_counts("matrix.mtx.gz"; sample_names="A",
                feature_filenames="features.tsv.gz", barcode_filenames="barcodes.tsv.gz")
```

`feature_filenames`/`barcode_filenames` accept a single filename or a vector matching `filenames`;
`nothing` (default) guesses them (and for a `.h5` input the guess returns the `.h5` path itself).

## The pure-`.h5` path is unchanged (no hash change)

Existing `.h5` on-disk caches must stay valid, so the `.h5` path is kept byte-for-byte:

- `Impl.load_counts` takes the matrix specs positionally and the feature/barcode specs as keyword
  arguments that **default to the matrix specs** (`feature_specs = matrix_specs`,
  `barcode_specs = matrix_specs`) — i.e. for `.h5` all three components are read from the one file.
- When no explicit component files are given and **every input is `.h5`**, the public function passes
  no feature/barcode specs, so the top-level call is exactly the original
  `create_job(DataMatrixFunction(Impl.load_counts), matrix_specs; sample_names, prefilter, extra_id_cols, kwargs...)`
  and the four leaf readers receive identical arguments — the whole job graph, and every hash, is
  identical.

**Verified empirically:** an `.h5` load under the new code fully reuses a disk cache built by the
*old* code (every entry a cache hit, no new cache keys written).

## Implementation

The four leaf readers — `load_var` (features), `load_barcodes` (barcodes), `load_sample_matrix` and
`load_sample_matrix_metadata` (matrix) — are **unchanged and shared across formats**: the
`SingleCell10x` readers already dispatch on file extension (`.h5`/`.tsv`/`.csv`/`.mtx`), so each reads
its own component file. Sibling resolution reuses `SingleCell10x.guessfeaturefilename` /
`guessbarcodefilename`.

- `src/load.jl` — accept `.mtx`, add `feature_filenames`/`barcode_filenames`. When every input is
  `.h5` and no component files are given, take the original single-spec path unchanged; otherwise
  build `feature_specs`/`barcode_specs` (guessing the siblings when a component isn't given) and pass
  them alongside `matrix_specs`. Includes per-component length checks and an updated docstring.
- `src/Impl/load.jl` — the `Mat`/`Var` and `Obs` methods take `matrix_specs` positionally with
  `feature_specs`/`barcode_specs` keyword arguments defaulting to `matrix_specs`, routing each
  component to its reader.

## Testing

`test/load.jl` gains a `.mtx` testset (test data already ships in
`test/data/…/filtered_feature_bc_matrix/`):

- loads `matrix.mtx.gz` and checks the matrix `== expected_mat` (and `SparseMatrixCSC{Int64,Int32}`),
  obs identical to the `.h5` load, and `var` shared columns (`id`/`name`/`feature_type`) matching;
- **note:** a `features.tsv` has no `genome` column (present in `.h5`), so `var` is compared on the
  shared columns, not asserted fully equal;
- explicit `feature_filenames`/`barcode_filenames` matching the guessed paths yield the identical
  (deduplicated) job as guessing;
- a mismatched number of explicit feature or barcode filenames throws `ArgumentError`;
- a **mixed `.h5` + `.mtx`** load: both samples merge correctly (matrix blocks, obs, shared `var`
  columns); the `.h5`-only `genome` annotation becomes `"ambiguous"` after the merge, since it is
  inconsistent across samples (`combine_var`'s sentinel — standard cross-sample annotation behavior,
  not specific to `.mtx`).

`run_load_tests()` passes **42/42** on both the New and Reused Disk Cache passes; the package
precompiles cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
