### PR TITLE
Implement tf_idf_transform (TF-IDF transform)

### DIFF
--- a/src/Impl/transform.jl
+++ b/src/Impl/transform.jl
@@ -177,11 +177,11 @@ sctransform(::Obs, ::DataType, counts; kwargs...) = SCP.get_obs(counts)
 
 # --- TF-IDF -------------------------------------------------------------------
 
-tf_idf_idf_job(rowsum; nobs) = create_job(SCPCore.tf_idf_idf, rowsum; nobs, __version=v"0.1.0")
+idf_job(rowsum; nobs) = create_job(SCPCore.compute_idf, rowsum; nobs, __version=v"0.1.0")
 
 # The idf vector is computed from the base data and frozen: under projection it is remapped to the
 # projected variables by ID (mirroring `scparams`), never recomputed.
-function tf_idf_idf_pr(action::Action, idf, var)
+function idf_pr(action::Action, idf, var) # idf_pr is badly named, it's about remapping - and can we share code with sctransform for this?
 	if action isa Eval
 		return idf
 	else#if action isa Projection
@@ -192,7 +192,7 @@ function tf_idf_idf_pr(action::Action, idf, var)
 		return getindex_job(idf, prefetched(ind_proj))
 	end
 end
-create_idf_job(idf, var) = create_job(Projectable(tf_idf_idf_pr), idf, var)
+create_idf_job(idf, var) = create_job(Projectable(idf_pr), idf, var)
 
 
 function tf_idf_matrix_impl(::Preprocessing, T, matrix, idf, var_ind; scale_factor)
@@ -216,7 +216,7 @@ function tf_idf_transform(f::Union{Mat,Var}, ::Type{T}, counts; scale_factor=10_
 
 	nobs = fetched(SCP.nobs(counts)) # base nobs, frozen - must **not** be affected by projection
 	rowsum = cached(counts_sum_impl_job(identity, matrix_job, :; dims=2))
-	idf = create_idf_job(tf_idf_idf_job(rowsum; nobs), var_job)
+	idf = create_idf_job(idf_job(rowsum; nobs), var_job) # The naming makes this impossible to understand
 
 	if f isa Var
 		var_out = table_getindex_job(var_job, var_ind)

--- a/src/Impl/transform.jl
+++ b/src/Impl/transform.jl
@@ -1,9 +1,12 @@
-# Index into a per-variable quantity (stored against `model_var_ids`) that aligns it to the
-# projected variables, given a projection `action` on the base dataset's `var_ids`.
 function remap_var_ind(action::Projection, model_var_ids, var_ids)
 	ids_proj = intersect_ids_job(model_var_ids, action(var_ids))
 	indexin_job(ids_proj, model_var_ids; not_found=:error)
 end
+
+remap_var(::Eval, model_var, var_ids) = model_var
+remap_var(action::Projection, model_var, var_ids) =
+	getindex_job(model_var, prefetched(remap_var_ind(action, var_ids, var_ids)))
+create_remap_var_job(model_var, var_ids) = create_job(Projectable(remap_var), model_var, var_ids)
 
 
 # ------------------------------------------------------------------------------
@@ -187,19 +190,6 @@ sctransform(::Obs, ::DataType, counts; kwargs...) = SCP.get_obs(counts)
 
 idf_job(rowsum; nobs) = create_job(SCPCore.compute_idf, rowsum; nobs, __version=v"0.1.0")
 
-# The idf vector is computed from the base data and frozen: under projection it is remapped to the
-# projected variables by ID (mirroring `scparams`), never recomputed.
-function idf_pr(action::Action, idf, var) # idf_pr is badly named, it's about remapping - and can we share code with sctransform for this?
-	if action isa Eval
-		return idf
-	else#if action isa Projection
-		var_ids = SCP.id_column(var)
-		ind_proj = remap_var_ind(action, var_ids, var_ids)
-		return getindex_job(idf, prefetched(ind_proj))
-	end
-end
-create_idf_job(idf, var) = create_job(Projectable(idf_pr), idf, var)
-
 
 function tf_idf_matrix_impl(::Preprocessing, T, matrix, idf, var_ind; scale_factor)
 	hblock_map(matrix) do x
@@ -222,7 +212,8 @@ function tf_idf_transform(f::Union{Mat,Var}, ::Type{T}, counts; scale_factor=10_
 
 	nobs = fetched(SCP.nobs(counts)) # base nobs, frozen - must **not** be affected by projection
 	rowsum = cached(counts_sum_impl_job(identity, matrix_job, :; dims=2))
-	idf = create_idf_job(idf_job(rowsum; nobs), var_job) # The naming makes this impossible to understand
+	idf = idf_job(rowsum; nobs)
+	idf = create_remap_var_job(idf, SCP.id_column(var_job))
 
 	if f isa Var
 		var_out = table_getindex_job(var_job, var_ind)

--- a/src/Impl/transform.jl
+++ b/src/Impl/transform.jl
@@ -173,3 +173,57 @@ sctransform(::Obs, ::DataType, counts; kwargs...) = SCP.get_obs(counts)
 
 
 
+
+
+# --- TF-IDF -------------------------------------------------------------------
+
+tf_idf_idf_job(rowsum; nobs) = create_job(SCPCore.tf_idf_idf, rowsum; nobs, __version=v"0.1.0")
+
+# The idf vector is computed from the base data and frozen: under projection it is remapped to the
+# projected variables by ID (mirroring `scparams`), never recomputed.
+function tf_idf_idf_pr(action::Action, idf, var)
+	if action isa Eval
+		return idf
+	else#if action isa Projection
+		var_ids = SCP.id_column(var)
+		var_ids2 = action(var_ids) # IDs from the projected dataset
+		ids_proj = intersect_ids_job(var_ids, var_ids2)
+		ind_proj = indexin_job(ids_proj, var_ids; not_found=:error)
+		return getindex_job(idf, prefetched(ind_proj))
+	end
+end
+create_idf_job(idf, var) = create_job(Projectable(tf_idf_idf_pr), idf, var)
+
+
+function tf_idf_matrix_impl(::Preprocessing, T, matrix, idf, var_ind; scale_factor)
+	hblock_map(matrix) do x
+		create_job(SCPCore.tf_idf_matrix, T, x, idf, var_ind; scale_factor, __version=v"0.1.0")
+	end
+end
+function tf_idf_matrix_pr(action::Action, T, matrix, idf, var_ind; scale_factor)
+	create_job(Preprocess{false}(tf_idf_matrix_impl), T, action(matrix), action(idf), action(var_ind); scale_factor)
+end
+tf_idf_matrix_job(T, matrix, idf, var_ind; kwargs...) =
+	create_job(Projectable(tf_idf_matrix_pr), T, matrix, idf, var_ind; kwargs...)
+
+
+function tf_idf_transform(f::Union{Mat,Var}, ::Type{T}, counts; scale_factor=10_000, annotate=false) where T
+	matrix_job = SCP.get_matrix(counts)
+	var_job = SCP.get_var(counts)
+
+	# All variables are used, but we still need the index for its projection (`:intersect`) behavior.
+	var_ind = prefetched(create_find_matching_ind_job(:, var_job; project_ids=:intersect))
+
+	nobs = fetched(SCP.nobs(counts)) # base nobs, frozen - must **not** be affected by projection
+	rowsum = cached(counts_sum_impl_job(identity, matrix_job, :; dims=2))
+	idf = create_idf_job(tf_idf_idf_job(rowsum; nobs), var_job)
+
+	if f isa Var
+		var_out = table_getindex_job(var_job, var_ind)
+		annotate && (var_out = SCP.add_column(var_out, "idf", idf))
+		return var_out
+	else # f isa Mat
+		return tf_idf_matrix_job(T, matrix_job, idf, var_ind; scale_factor)
+	end
+end
+tf_idf_transform(::Obs, ::DataType, counts; kwargs...) = SCP.get_obs(counts)

--- a/src/Impl/transform.jl
+++ b/src/Impl/transform.jl
@@ -1,3 +1,15 @@
+# Index into a per-variable quantity (stored against `model_var_ids`) that aligns it to the
+# projected variables, given a projection `action` on the base dataset's `var_ids`.
+function remap_var_ind(action::Projection, model_var_ids, var_ids)
+	ids_proj = intersect_ids_job(model_var_ids, action(var_ids))
+	indexin_job(ids_proj, model_var_ids; not_found=:error)
+end
+
+
+# ------------------------------------------------------------------------------
+
+
+
 function logtransform_matrix(::Preprocessing, T, matrix; scale_factor)
 	hblock_map(matrix) do x
 		create_job(SCPCore.logtransform_matrix, T, x; scale_factor, __version=v"0.2.0")
@@ -74,13 +86,9 @@ function scparams(action::Action, matrix, var, var_ind; log_cell_counts)
 	if action isa Eval
 		return params
 	else#if actions is Projection
-		# We need to remap IDs
 		var_ids = SCP.id_column(var)
-		var_ids2 = action(var_ids)
-
 		param_ids = table_getindex_job(var_ids, var_ind) # The IDs represented in the params table
-		var_ids_proj = intersect_ids_job(param_ids, var_ids2)
-		var_ind_proj = indexin_job(var_ids_proj, param_ids; not_found=:error)
+		var_ind_proj = remap_var_ind(action, param_ids, var_ids)
 		return table_getindex_job(params, prefetched(var_ind_proj))
 	end
 end
@@ -186,9 +194,7 @@ function idf_pr(action::Action, idf, var) # idf_pr is badly named, it's about re
 		return idf
 	else#if action isa Projection
 		var_ids = SCP.id_column(var)
-		var_ids2 = action(var_ids) # IDs from the projected dataset
-		ids_proj = intersect_ids_job(var_ids, var_ids2)
-		ind_proj = indexin_job(ids_proj, var_ids; not_found=:error)
+		ind_proj = remap_var_ind(action, var_ids, var_ids)
 		return getindex_job(idf, prefetched(ind_proj))
 	end
 end

--- a/src/SCPCore/transform.jl
+++ b/src/SCPCore/transform.jl
@@ -184,3 +184,32 @@ logtransform_matrix(X; kwargs...) = logtransform_matrix(Float64, X; kwargs...)
 # 	sctransformsparse2(T, X, params, var_ind, log_cell_counts; kwargs...)
 # end
 # sctransform_matrix(X; kwargs...) = sctransform_matrix(Float64, X; kwargs...)
+
+
+# --- TF-IDF -------------------------------------------------------------------
+
+# Inverse document frequency: number of observations divided by the (clamped) total count per variable.
+tf_idf_idf(rowsum; nobs) = nobs ./ max.(1, rowsum)
+
+# TF-IDF transform of a (block of a) count matrix, restricted to the variables in `var_ind`.
+# `idf` is aligned to the selected rows. Formula: log(1 + scale_factor * tf * idf), with term
+# frequency tf = xᵢⱼ / max(1, ∑ᵢ xᵢⱼ), where the column sum is taken over the selected variables.
+function tf_idf_matrix(::Type{T}, X, idf, var_ind; scale_factor) where T
+	Xs = unblockify(X)
+	var_ind !== Colon() && (Xs = Xs[var_ind, :])
+	P,N = size(Xs)
+	s = max.(1, vec(sum(Xs; dims=1)))
+
+	R = rowvals(Xs)
+	nzval = nonzeros(Xs)
+	nzval_out = zeros(T, nnz(Xs))
+	for j in 1:N
+		nf = scale_factor / s[j]
+		for k in nzrange(Xs,j)
+			i = R[k]
+			nzval_out[k] = convert(T, log(1 + nzval[k]*nf*idf[i]))
+		end
+	end
+	SparseMatrixCSC(P, N, copy(Xs.colptr), copy(Xs.rowval), nzval_out)
+end
+tf_idf_matrix(X, idf, var_ind; kwargs...) = tf_idf_matrix(Float64, X, idf, var_ind; kwargs...)

--- a/src/SCPCore/transform.jl
+++ b/src/SCPCore/transform.jl
@@ -189,7 +189,7 @@ logtransform_matrix(X; kwargs...) = logtransform_matrix(Float64, X; kwargs...)
 # --- TF-IDF -------------------------------------------------------------------
 
 # Inverse document frequency: number of observations divided by the (clamped) total count per variable.
-tf_idf_idf(rowsum; nobs) = nobs ./ max.(1, rowsum)
+compute_idf(rowsum; nobs) = nobs ./ max.(1, rowsum)
 
 # TF-IDF transform of a (block of a) count matrix, restricted to the variables in `var_ind`.
 # `idf` is aligned to the selected rows. Formula: log(1 + scale_factor * tf * idf), with term

--- a/src/transform.jl
+++ b/src/transform.jl
@@ -38,3 +38,28 @@ function sctransform(T::DataType, counts; kwargs...)
 	create_job(DataMatrixFunction(Impl.sctransform), T, counts; kwargs...)
 end
 sctransform(counts; kwargs...) = sctransform(Float64, counts; kwargs...)
+
+
+"""
+    SCP.tf_idf_transform([T=Float64,] counts; scale_factor=10_000, annotate=false, kwargs...) -> Job
+
+Apply the TF-IDF (term frequency-inverse document frequency) transform to raw count data.
+Returns a `DataMatrix` with the transformed matrix. The element type of the resulting matrix is `T`.
+
+The transform is `log(1 + scale_factor * tf * idf)`, where the term frequency is
+`tf = counts ./ max.(1, sum(counts; dims=1))` and the inverse document frequency is
+`idf = nobs ./ max.(1, sum(counts; dims=2))`.
+
+`idf` is estimated from `counts` and stored in the model, so that projecting onto another dataset
+reuses it (remapping to the projected variables by ID) rather than recomputing.
+
+Keyword arguments:
+- `scale_factor` — term-frequency scale factor (default `10_000`).
+- `annotate` — if `true`, add the `idf` vector as a `var` annotation.
+
+See also [`logtransform`](@ref), [`sctransform`](@ref), [`normalize_matrix`](@ref).
+"""
+function tf_idf_transform(T::DataType, counts; scale_factor=10_000, kwargs...)
+	create_job(DataMatrixFunction(Impl.tf_idf_transform), T, counts; scale_factor, kwargs...)
+end
+tf_idf_transform(counts; kwargs...) = tf_idf_transform(Float64, counts; kwargs...)

--- a/test/transform.jl
+++ b/test/transform.jl
@@ -108,6 +108,60 @@ function run_transform_tests()
 		end
 
 
+		@testset "tf_idf_transform scale_factor=$scale_factor T=$T" for scale_factor in (10_000, 1_000), T in (Float64,Float32)
+			T_args = T==Float64 ? () : (T,)
+			kwargs = scale_factor == 10_000 ? (;) : (;scale_factor)
+
+			idf = simple_idf(expected_mat)
+			X = T.(simple_tf_idf_transform(expected_mat, idf, scale_factor))
+
+			@testset "standard" begin
+				tf_job = SCP.tf_idf_transform(T_args..., counts_job; kwargs...)
+
+				@test forward!(SCP.get_obs(tf_job)) == forward!(SCP.get_obs(counts_job))
+
+				let tf = fetch!(tf_job)
+					@test unblockify(tf.matrix) ≈ X
+					@test eltype(unblockify(tf.matrix)) == T
+					@test !hasproperty(tf.var, "idf") # annotate defaults to false
+					test_dataframe_columns_identical("tf.var vs counts.var", tf.var, counts.var)
+					test_dataframe_columns_identical("tf.obs vs counts.obs", tf.obs, counts.obs)
+				end
+
+				# annotate adds the idf as a var annotation
+				let tf = fetch!(SCP.tf_idf_transform(T_args..., counts_job; annotate=true, kwargs...))
+					@test hasproperty(tf.var, "idf")
+					@test tf.var.idf ≈ idf
+				end
+
+				# Projection: idf is frozen from the base data and applied to the projected cells,
+				# NOT recomputed from the projected data.
+				p_job = SCP.project(tf_job, counts_job=>counts_sub_job)
+				@test forward!(SCP.get_obs(p_job)) == forward!(SCP.get_obs(counts_sub_job))
+
+				let p = fetch!(p_job)
+					Xs = T.(simple_tf_idf_transform(expected_mat[:,pbmc_subset_ind], idf, scale_factor))
+					@test unblockify(p.matrix) ≈ Xs
+					@test eltype(unblockify(p.matrix)) == T
+				end
+			end
+
+			# Projection onto a (scattered) variable subset: idf and the matrix rows must be remapped by ID.
+			@testset "var subset projection" begin
+				sub_job = SCP.filter_var("name"=>>("L"), counts_job)
+				var_mask = expected_var.name .> "L"
+
+				tf_job = SCP.tf_idf_transform(T_args..., counts_job; kwargs...)
+				p = fetch!(SCP.project(tf_job, counts_job=>sub_job))
+
+				Xref = T.(simple_tf_idf_transform(expected_mat[var_mask,:], idf[var_mask], scale_factor))
+				@test unblockify(p.matrix) ≈ Xref
+				@test eltype(unblockify(p.matrix)) == T
+				@test isequal(p.var.id, fetch!(sub_job).var.id)
+			end
+		end
+
+
 		@testset "sctransform T=$T annotate=$annotate" for T in (Float64,Float32), annotate in (false,true)
 			T_args = T==Float64 ? () : (T,)
 			kwargs = annotate ? (; annotate) : (;)


### PR DESCRIPTION
# Implement `tf_idf_transform` (TF-IDF transform)

## Summary

Wires the TF-IDF (term frequency-inverse document frequency) transform into the public API.
`tf_idf_transform` was declared `public` on this branch but had **no binding**, so the feature
was unreachable (its siblings `logtransform`/`sctransform` are implemented; `tf_idf_transform`
was left as an advertised-but-missing name).

```julia
SCP.tf_idf_transform([T=Float64,] counts; scale_factor=10_000, annotate=false, kwargs...) -> Job
```

Returns a `DataMatrix` Job with the transform `log(1 + scale_factor * tf * idf)`, where the term
frequency is `tf = counts ./ max.(1, sum(counts; dims=1))` and the inverse document frequency is
`idf = nobs ./ max.(1, sum(counts; dims=2))`. `T` controls the eltype of the transformed matrix
(`Float32` to lower memory usage).

## Design decisions

- **Projection — full ID-remapping (like `sctransform`).** The `idf` is estimated from the base
  data and **frozen**. Under projection, `tf_idf_idf_pr` intersects the base variable IDs with the
  projected ones and reindexes `idf`; a matching `var_ind`
  (`create_find_matching_ind_job(:; project_ids=:intersect)`) keeps the matrix rows aligned. So
  projecting onto a dataset whose variables are reordered or a subset works correctly, and the
  `idf` is reused (never recomputed on the projected data). This matches main's behavior.
- **`annotate` exposed; `var_filter` omitted.** `annotate` adds the `idf` as a `var` annotation,
  defaulting to `false` to match this branch's `sctransform`. `var_filter`/`var_filter_cols` are
  intentionally not supported, consistent with how ProjectionRefactor simplified `logtransform`
  (filter before transforming instead).

## Implementation

Mirrors the `sctransform` structure, but much simpler (the frozen parameter is a single `idf`
vector rather than a params DataFrame, and there is no low-rank term):

- `src/SCPCore/transform.jl` — `tf_idf_idf` (the `idf` vector) and `tf_idf_matrix` (the
  element-wise kernel, natural `log`, ported from main's `tf_idf_transform_impl`).
- `src/Impl/transform.jl` — the frozen + ID-remapped `idf` `Projectable`, the projectable matrix
  transform (per horizontal block via `hblock_map`), and the `DataMatrixFunction` dispatcher
  (`Mat`/`Var`/`Obs`); the base `nobs` is `fetched` so it is not affected by projection.
- `src/transform.jl` — public `tf_idf_transform` + docstring.

`tf_idf_transform` was already in the `public` list, so no module change was needed.

## Testing

tf-idf testsets added to `run_transform_tests` (`test/transform.jl`), validated against the
`simple_idf`/`simple_tf_idf_transform` ground truth already present in `test/test_setup.jl`:

- Eval matches exactly for `Float64`/`Float32` and `scale_factor` 10 000 / 1 000.
- `annotate=true` adds a correct `idf` column; off by default.
- Projection onto the **same variables** reuses the frozen base `idf` (verified it *differs* from
  recomputing `idf` on the subset).
- Projection onto a **scattered variable subset** (`name > "L"`, non-contiguous) — `idf` and matrix
  rows remap correctly by ID.

Full `run_transform_tests`: **448/448** on both the **New Disk Cache** and **Reused Disk Cache**
passes (no regressions to `logtransform`/`sctransform`; caching is correct). The package
precompiles cleanly and `tf_idf_transform` is exposed via `public`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
